### PR TITLE
DOCS: Examples in soy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ claycss.json
 dist
 node_modules
 temp
+.temp

--- a/electric.config.js
+++ b/electric.config.js
@@ -25,6 +25,7 @@ module.exports = {
 	frontMatterHook: function(data) {
 		return generateIconData(data);
 	},
+	codeMirrorLanguages: ['xml', 'soy'],
 	metalComponents: ['electric-quartz-components'],
 	sassOptions: {
 		includePaths: ['node_modules', clayIncludePaths]

--- a/electric.config.js
+++ b/electric.config.js
@@ -25,7 +25,7 @@ module.exports = {
 	frontMatterHook: function(data) {
 		return generateIconData(data);
 	},
-	codeMirrorLanguages: ['xml', 'soy'],
+	codeMirrorLanguages: ['xml', 'htmlmixed', 'soy'],
 	metalComponents: ['electric-quartz-components'],
 	sassOptions: {
 		includePaths: ['node_modules', clayIncludePaths]

--- a/src/pages/docs/components/alerts.md
+++ b/src/pages/docs/components/alerts.md
@@ -256,7 +256,7 @@ weight: 100
 	<strong class="lead">Dark:</strong> This is a <a href="#1" class="alert-link">dark alert</a>.
 </div>
 
-```xml
+```text/html
 <div class="alert alert-dismissible alert-primary" role="alert">
 	<button aria-label="Close" class="close" data-dismiss="alert" type="button">
 		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
@@ -434,7 +434,7 @@ weight: 100
 	<strong class="lead">Dark</strong> This is a <a href="#1" class="alert-link">dark alert</a>.
 </div>
 
-```xml
+```text/html
 <div class="alert alert-fluid alert-primary" role="alert">
 	<strong class="lead">Primary</strong> This is a <a href="#1" class="alert-link">primary alert</a>.
 </div>
@@ -612,7 +612,7 @@ weight: 100
 	<p>Due to inactivity, your session has expired. Please save any data you may have entered before refreshing the page. <a class="alert-link" href="#1">Log in</a></p>
 </div>
 
-```xml
+```text/html
 <div class="alert alert-dismissible alert-notification alert-success" role="alert">
 	<button aria-label="Close" class="close" data-dismiss="alert" type="button">
 		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">

--- a/src/pages/docs/components/alerts.md
+++ b/src/pages/docs/components/alerts.md
@@ -62,7 +62,7 @@ weight: 100
 	<strong class="lead">Dark:</strong> This is a <a href="#1" class="alert-link">dark alert</a>.
 </div>
 
-```xml
+```text/html
 <div class="alert alert-primary" role="alert">
 	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
 		<use xlink:href="/vendor/lexicon/icons.svg#info-circle"></use>

--- a/src/pages/docs/components/alerts.md
+++ b/src/pages/docs/components/alerts.md
@@ -119,6 +119,46 @@ weight: 100
 	<strong class="lead">Dark:</strong> This is a <a href="#1" class="alert-link">dark alert</a>.
 </div>
 ```
+```soy
+{call ClayAlert.render}
+	{param message kind="html"}
+		You just read the <a href="#">alert message</a> successfully.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'success' /}
+	{param title: 'Success' /}
+{/param}
+
+{call ClayAlert.render}
+	{param message kind="html"}
+		This <a href="#">alert</a> needs your attention.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Info' /}
+{/param}
+
+{call ClayAlert.render}
+	{param message kind="html"}
+		This alert is a <a href="#">warning message</a>.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'warning' /}
+	{param title: 'Warning' /}
+{/param}
+
+{call ClayAlert.render}
+	{param message kind="html"}
+		Something</a> is not right.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'danger' /}
+	{param title: 'Danger' /}
+{/param}
+```
 
 </article>
 
@@ -313,6 +353,54 @@ weight: 100
 	<strong class="lead">Dark:</strong> This is a <a href="#1" class="alert-link">dark alert</a>.
 </div>
 ```
+```soy
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		You just read the <a href="#">alert message</a> successfully.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'success' /}
+	{param title: 'Success' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		This <a href="#">alert</a> needs your attention.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Info' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		This alert is a <a href="#">warning message</a>.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'warning' /}
+	{param title: 'Warning' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		Something</a> is not right.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'danger' /}
+	{param title: 'Danger' /}
+{/param}
+```
 
 </article>
 
@@ -378,6 +466,58 @@ weight: 100
 <div class="alert alert-dark alert-fluid" role="alert">
 	<strong class="lead">Dark</strong> This is a <a href="#1" class="alert-link">dark alert</a>.
 </div>
+```
+```soy
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		You just read the <a href="#">alert message</a> successfully.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'success' /}
+	{param title: 'Success' /}
+	{param type: 'fluid' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		This <a href="#">alert</a> needs your attention.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Info' /}
+	{param type: 'fluid' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		This alert is a <a href="#">warning message</a>.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'warning' /}
+	{param title: 'Warning' /}
+	{param type: 'fluid' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		Something</a> is not right.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'danger' /}
+	{param title: 'Danger' /}
+	{param type: 'fluid' /}
+{/param}
 ```
 
 </article>
@@ -562,6 +702,60 @@ weight: 100
 	<strong class="lead">Dark:</strong>
 	<p>Due to inactivity, your session has expired. Please save any data you may have entered before refreshing the page. <a class="alert-link" href="#1">Log in</a></p>
 </div>
+```
+```soy
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		<p>The UX Team has rescheduled to the following date: 2014 - 12 - 17.</p>
+		<p>Please complete the attendance form to confirm your attendance: <a href="#1">More Info</a>.</p>
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'success' /}
+	{param title: 'Meeting Rescheduled' /}
+	{param type: 'notification' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		<p>The UX Team has rescheduled to the following date: 2014 - 12 - 17.</p>
+		<p>Please complete the attendance form to confirm your attendance: <a href="#1">More Info</a>.</p>
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Meeting Rescheduled' /}
+	{param type: 'notification' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		<p>Due to inactivity, your session will expire in 00:00:56. To extend your session another 2 minutes click: <a href="#1">Extend</a>.</p>
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'warning' /}
+	{param title: 'Warning:' /}
+	{param type: 'notification' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		<p>Due to inactivity, your session has expired. Please save any data you may have entered before refreshing the page. <a href="#1">Log in</a></p>
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'danger' /}
+	{param title: 'Danger:' /}
+	{param type: 'notification' /}
+{/param}
 ```
 
 </article>

--- a/src/pages/docs/components/badges_and_labels.md
+++ b/src/pages/docs/components/badges_and_labels.md
@@ -418,6 +418,47 @@ weight: 100
 <span class="sticker sticker-light">133</span>
 <span class="sticker sticker-dark">133</span>
 ```
+```soy
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'primary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'secondary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'success' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'info' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'warning' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'danger' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'light' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'dark' /}
+{/call}
+```
 
 </article>
 
@@ -473,6 +514,31 @@ weight: 100
 	<span class="sticker sticker-bottom-right sticker-danger">PDF</span>
 </div>
 ```
+```soy
+{call ClaySticker.render}
+	{param label: 'PDF' /}
+	{param position: 'top-left' /}
+	{param style: 'danger' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: 'PDF' /}
+	{param position: 'bottom-left' /}
+	{param style: 'danger' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: 'PDF' /}
+	{param position: 'top-right' /}
+	{param style: 'danger' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: 'PDF' /}
+	{param position: 'bottom-right' /}
+	{param style: 'danger' /}
+{/call}
+```
 
 </article>
 
@@ -495,6 +561,30 @@ weight: 100
 <span class="sticker sticker-lg sticker-success">133</span>
 <span class="sticker sticker-xl sticker-info">133</span>
 <span class="sticker sticker-xxl sticker-warning">133</span>
+```
+```soy
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param size: 'sm' /}
+	{param style: 'primary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'secondary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param size: 'lg' /}
+	{param style: 'success' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param size: 'xl' /}
+	{param style: 'info' /}
+{/call}
 ```
 
 <span class="sticker sticker-xxl sticker-warning">
@@ -549,6 +639,42 @@ weight: 100
 		<use xlink:href="/vendor/lexicon/icons.svg#folder" />
 	</svg>
 </span>
+```
+```soy
+{call ClaySticker.render}
+	{param icon: [
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'magic'
+	] /}
+	{param size: 'xl' /}
+	{param style: 'success' /}
+{/call}
+
+{call ClaySticker.render}
+	{param icon: [
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'picture'
+	] /}
+	{param size: 'lg' /}
+	{param style: 'success' /}
+{/call}
+
+{call ClaySticker.render}
+	{param icon: [
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'home'
+	] /}
+	{param style: 'secondary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param icon: [
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'format'
+	] /}
+	{param size: 'sm' /}
+	{param style: 'primary' /}
+{/call}
 ```
 
 </article>
@@ -640,6 +766,51 @@ weight: 100
 	Email
 	<span class="rounded-circle sticker sticker-bottom-right sticker-danger sticker-outside">133</span>
 </button>
+```
+```soy
+{call ClayButton.render}
+	{param label kind="xml"}
+		{call ClaySticker.render}
+			{param label: '133' /}
+			{param outside: 'top-left' /}
+			{param shape: 'circle' /}
+			{param style: 'danger' /}
+		{/call}
+	{/param}
+{/call}
+
+{call ClayButton.render}
+	{param label kind="xml"}
+		{call ClaySticker.render}
+			{param label: '133' /}
+			{param outside: 'bottom-left' /}
+			{param shape: 'circle' /}
+			{param style: 'danger' /}
+		{/call}
+	{/param}
+{/call}
+
+{call ClayButton.render}
+	{param label kind="xml"}
+		{call ClaySticker.render}
+			{param label: '133' /}
+			{param outside: 'top-right' /}
+			{param shape: 'circle' /}
+			{param style: 'danger' /}
+		{/call}
+	{/param}
+{/call}
+
+{call ClayButton.render}
+	{param label kind="xml"}
+		{call ClaySticker.render}
+			{param label: '133' /}
+			{param outside: 'bottom-right' /}
+			{param shape: 'circle' /}
+			{param style: 'danger' /}
+		{/call}
+	{/param}
+{/call}
 ```
 
 <div class="row">
@@ -795,6 +966,30 @@ weight: 100
 <span class="rounded-circle sticker sticker-info sticker-lg">SP</span>
 <span class="rounded-circle sticker sticker-primary sticker-xl">WW</span>
 <span class="rounded-circle sticker sticker-success sticker-xxl">TT</span>
+```
+```soy
+{call ClaySticker.render}
+	{param label: 'JB' /}
+	{param size: 'sm' /}
+	{param style: 'secondary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: 'TT' /}
+	{param style: 'danger' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: 'SP' /}
+	{param size: 'lg' /}
+	{param style: 'info' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: 'WW' /}
+	{param size: 'xl' /}
+	{param style: 'primary' /}
+{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/badges_and_labels.md
+++ b/src/pages/docs/components/badges_and_labels.md
@@ -28,6 +28,21 @@ weight: 100
 <span class="badge badge-light">130</span>
 <span class="badge badge-dark">130</span>
 ```
+```soy
+{call ClayBadge.render}
+	{param: label: '8' /}
+{/param}
+
+{call ClayBadge.render}
+	{param: label: '87' /}
+	{param: style: 'secondary' /}
+{/param}
+
+{call ClayBadge.render}
+	{param: label: '999K' /}
+	{param: style: 'success' /}
+{/param}
+```
 
 </article>
 

--- a/src/pages/docs/components/badges_and_labels.md
+++ b/src/pages/docs/components/badges_and_labels.md
@@ -202,6 +202,31 @@ weight: 100
 <span class="label label-light">Light</span>
 <span class="label label-dark">Dark</span>
 ```
+```soy
+{call ClayLabel.render}
+	{param label: 'Label Text' /}
+{/call}
+
+{call ClayLabel.render}
+	{param label: 'Status' /}
+	{param style: 'info' /}
+{/call}
+
+{call ClayLabel.render}
+	{param label: 'Pending' /}
+	{param style: 'warning' /}
+{/call}
+
+{call ClayLabel.render}
+	{param label: 'Rejected' /}
+	{param style: 'danger' /}
+{/call}
+
+{call ClayLabel.render}
+	{param label: 'Approved' /}
+	{param style: 'success' /}
+{/call}
+```
 
 </article>
 
@@ -229,6 +254,36 @@ weight: 100
 <a class="label label-light" href="#1">Light</a>
 <a class="label label-dark" href="#1">Dark</a>
 ```
+```soy
+{call ClayLabel.render}
+	{param href: '#1' /}
+	{param label: 'Label Text' /}
+{/call}
+
+{call ClayLabel.render}
+	{param href: '#1' /}
+	{param label: 'Status' /}
+	{param style: 'info' /}
+{/call}
+
+{call ClayLabel.render}
+	{param href: '#1' /}
+	{param label: 'Pending' /}
+	{param style: 'warning' /}
+{/call}
+
+{call ClayLabel.render}
+	{param href: '#1' /}
+	{param label: 'Rejected' /}
+	{param style: 'danger' /}
+{/call}
+
+{call ClayLabel.render}
+	{param href: '#1' /}
+	{param label: 'Approved' /}
+	{param style: 'success' /}
+{/call}
+```
 
 </article>
 
@@ -247,6 +302,18 @@ weight: 100
 <span class="label label-primary label-sm">Small Label</span>
 <span class="label label-secondary">Normal Label</span>
 <span class="label label-lg label-success">Large Label</span>
+```
+```soy
+{call ClayLabel.render}
+	{param label: 'Small Label' /}
+	{param size: 'sm' /}
+	{param style: 'info' /}
+{/call}
+
+{call ClayLabel.render}
+	{param closeable: true /}
+	{param label: 'Normal Label' /}
+{/call}
 ```
 
 </article>
@@ -306,6 +373,21 @@ weight: 100
 		</svg>
 	</button>
 </span>
+```
+```soy
+{call ClayLabel.render}
+	{param closeable: true /}
+	{param label: 'Small Label' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param size: 'sm' /}
+	{param style: 'info' /}
+{/call}
+
+{call ClayLabel.render}
+	{param closeable: true /}
+	{param label: 'Normal Label' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/badges_and_labels.md
+++ b/src/pages/docs/components/badges_and_labels.md
@@ -18,7 +18,7 @@ weight: 100
 <span class="badge badge-light">130</span>
 <span class="badge badge-dark">130</span>
 
-```xml
+```text/html
 <span class="badge badge-primary">8</span>
 <span class="badge badge-secondary">87</span>
 <span class="badge badge-success">999K</span>
@@ -60,7 +60,7 @@ weight: 100
 <a class="badge badge-light" href="#1">Light</a>
 <a class="badge badge-dark" href="#1">Dark</a>
 
-```xml
+```text/html
 <a class="badge badge-primary" href="#1">Primary</a>
 <a class="badge badge-secondary" href="#1">Secondary</a>
 <a class="badge badge-success" href="#1">Success</a>
@@ -87,7 +87,7 @@ weight: 100
 <span class="badge badge-light badge-pill">130</span>
 <span class="badge badge-dark badge-pill">130</span>
 
-```xml
+```text/html
 <span class="badge badge-pill badge-primary">8</span>
 <span class="badge badge-pill badge-secondary">87</span>
 <span class="badge badge-pill badge-success">999K</span>
@@ -111,7 +111,7 @@ weight: 100
 <span class="badge badge-secondary">Normal Badge</span>
 <span class="badge badge-lg badge-success">Large Badge</span>
 
-```xml
+```text/html
 <span class="badge badge-primary badge-sm">Small Badge</span>
 <span class="badge badge-secondary">Normal Badge</span>
 <span class="badge badge-lg badge-success">Large Badge</span>
@@ -149,7 +149,7 @@ weight: 100
 	</button>
 </span>
 
-```xml
+```text/html
 <span class="badge badge-primary badge-sm">
 	<a href="#1">Small Badge</a>
 	<button aria-label="Close" class="close" type="button">
@@ -192,7 +192,7 @@ weight: 100
 <span class="label label-light">Light</span>
 <span class="label label-dark">Dark</span>
 
-```xml
+```text/html
 <span class="label label-primary">Primary</span>
 <span class="label label-secondary">Secondary</span>
 <span class="label label-success">Success</span>
@@ -244,7 +244,7 @@ weight: 100
 <a class="label label-light" href="#1">Light</a>
 <a class="label label-dark" href="#1">Dark</a>
 
-```xml
+```text/html
 <a class="label label-primary" href="#1">Primary</a>
 <a class="label label-secondary" href="#1">Secondary</a>
 <a class="label label-success" href="#1">Success</a>
@@ -298,7 +298,7 @@ weight: 100
 <span class="label label-secondary">Normal Label</span>
 <span class="label label-lg label-success">Large Label</span>
 
-```xml
+```text/html
 <span class="label label-primary label-sm">Small Label</span>
 <span class="label label-secondary">Normal Label</span>
 <span class="label label-lg label-success">Large Label</span>
@@ -348,7 +348,7 @@ weight: 100
 	</button>
 </span>
 
-```xml
+```text/html
 <span class="label label-primary label-sm">
 	<a href="#1">Small Label</a>
 	<button aria-label="Close" class="close" type="button">
@@ -408,7 +408,7 @@ weight: 100
 <span class="sticker sticker-light">133</span>
 <span class="sticker sticker-dark">133</span>
 
-```xml
+```text/html
 <span class="sticker sticker-primary">133</span>
 <span class="sticker sticker-secondary">133</span>
 <span class="sticker sticker-success">133</span>
@@ -496,7 +496,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="aspect-ratio">
 	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
 	<span class="sticker sticker-danger sticker-top-left">PDF</span>
@@ -555,7 +555,7 @@ weight: 100
 <span class="sticker sticker-xl sticker-info">133</span>
 <span class="sticker sticker-xxl sticker-warning">133</span>
 
-```xml
+```text/html
 <span class="sticker sticker-primary sticker-sm">133</span>
 <span class="sticker sticker-secondary">133</span>
 <span class="sticker sticker-lg sticker-success">133</span>
@@ -613,7 +613,7 @@ weight: 100
 	</svg>
 </span>
 
-```xml
+```text/html
 <span class="sticker sticker-xxl sticker-warning">
 	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-magic">
 		<use xlink:href="/vendor/lexicon/icons.svg#magic" />
@@ -749,7 +749,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <button class="btn btn-primary" style="position:relative;">
 	Email
 	<span class="rounded-circle sticker sticker-danger sticker-outside sticker-top-left">133</span>
@@ -864,7 +864,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <span class="sticker sticker-dark">
 	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
 		<use xlink:href="/vendor/lexicon/icons.svg#picture" />
@@ -933,7 +933,7 @@ weight: 100
 	<img alt="thumbnail" class="img-fluid" src="../../images/thumbnail_typewriter.jpg">
 </span>
 
-```xml
+```text/html
 <span class="rounded-circle sticker sticker-primary sticker-sm">
 	<img alt="thumbnail" class="img-fluid" src="/images/thumbnail_dock.jpg">
 </span>
@@ -960,7 +960,7 @@ weight: 100
 <span class="rounded-circle sticker sticker-primary sticker-xl">WW</span>
 <span class="rounded-circle sticker sticker-success sticker-xxl">TT</span>
 
-```xml
+```text/html
 <span class="rounded-circle sticker sticker-secondary sticker-sm">JB</span>
 <span class="rounded-circle sticker sticker-danger">TT</span>
 <span class="rounded-circle sticker sticker-info sticker-lg">SP</span>

--- a/src/pages/docs/components/breadcrumbs.md
+++ b/src/pages/docs/components/breadcrumbs.md
@@ -48,7 +48,7 @@ weight: 100
 	</li>
 </ol>
 
-```xml
+```text/html
 <ol class="breadcrumb">
 	<li class="breadcrumb-item">
 		<a class="breadcrumb-link" href="#1" title="Home">
@@ -127,7 +127,7 @@ weight: 100
 	</li>
 </ol>
 
-```xml
+```text/html
 <ol class="breadcrumb">
 	<li class="breadcrumb-item dropdown">
 		<a aria-expanded="false" aria-haspopup="true" class="breadcrumb-link dropdown-toggle" data-toggle="dropdown" href="" id="breadcrumb2Dropdown1" role="button">
@@ -217,7 +217,7 @@ weight: 100
 	</li>
 </ol>
 
-```xml
+```text/html
 <ol class="breadcrumb">
 	<li class="breadcrumb-item dropdown">
 		<a aria-expanded="false" aria-haspopup="true" class="breadcrumb-link dropdown-toggle" data-toggle="dropdown" href="#1" id="breadcrumb3Dropdown1" role="button" title="Dropdown">

--- a/src/pages/docs/components/button_group.md
+++ b/src/pages/docs/components/button_group.md
@@ -15,7 +15,7 @@ weight: 100
 	<button class="btn btn-secondary" type="button">Right</button>
 </div>
 
-```xml
+```text/html
 <div class="btn-group" role="group">
 	<button class="btn btn-secondary" type="button">Left</button>
 	<button class="btn btn-secondary" type="button">Middle</button>
@@ -109,7 +109,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="btn-group dropdown" role="group">
 	<button class="btn btn-primary" type="button">Primary</button>
 	<button aria-expanded="false" aria-haspopup="true" class="btn btn-primary btn-monospaced dropdown-toggle" data-toggle="dropdown" type="button">
@@ -228,7 +228,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="btn-group dropup" role="group">
 	<button class="btn btn-primary" type="button">Right dropup</button>
 	<button aria-expanded="false" aria-haspopup="true" class="btn btn-primary btn-monospaced dropdown-toggle" data-toggle="dropdown" type="button">
@@ -309,7 +309,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="btn-group-vertical" role="group">
 	<button class="btn btn-secondary" type="button">Button</button>
 	<button class="btn btn-secondary" type="button">Button</button>
@@ -380,7 +380,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-label="Toolbar with button groups" class="btn-toolbar" role="toolbar">
 	<div aria-label="First group" class="btn-group" role="group">
 		<button type="button" class="btn btn-secondary">1</button>
@@ -426,7 +426,7 @@ weight: 100
 	<button class="btn btn-secondary" type="button">Right</button>
 </div>
 
-```xml
+```text/html
 <div class="btn-group btn-group-sm" role="group">
 	<button class="btn btn-secondary" type="button">Left</button>
 	<button class="btn btn-secondary" type="button">Middle</button>
@@ -484,7 +484,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="btn-group btn-group-sm dropdown" role="group">
 	<button class="btn btn-primary" type="button">Primary</button>
 	<button aria-expanded="false" aria-haspopup="true" class="btn btn-primary btn-monospaced dropdown-toggle" data-toggle="dropdown" type="button">
@@ -647,7 +647,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="btn-group-vertical btn-group-sm" role="group">
 	<button class="btn btn-secondary" type="button">Button</button>
 	<button class="btn btn-secondary" type="button">Button</button>

--- a/src/pages/docs/components/buttons.md
+++ b/src/pages/docs/components/buttons.md
@@ -32,6 +32,36 @@ weight: 100
 <button class="btn btn-link" type="button">Link</button>
 <button class="btn btn-unstyled" type="button">Unstyled</button>
 ```
+```soy
+{call ClayButton.render}
+	{param label: 'Primary' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param label: 'Secondary' /}
+	{param style: 'secondary' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param label: 'Link' /}
+	{param style: 'link' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param label: 'Borderless' /}
+	{param style: 'borderless' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param label: 'Unstyled' /}
+	{param style: 'unstyled' /}
+	{param type: 'button' /}
+{/call}
+```
 
 ### Focus
 
@@ -71,6 +101,41 @@ weight: 100
 <button class="active btn btn-link" type="button">Link</button>
 <button class="active btn btn-unstyled" type="button">Unstyled</button>
 ```
+```soy
+{call ClayButton.render}
+	{param elementClasses: 'focus' /}
+	{param label: 'Primary' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param elementClasses: 'focus' /}
+	{param label: 'Secondary' /}
+	{param style: 'secondary' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param elementClasses: 'focus' /}
+	{param label: 'Link' /}
+	{param style: 'link' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param elementClasses: 'focus' /}
+	{param label: 'Borderless' /}
+	{param style: 'borderless' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param elementClasses: 'focus' /}
+	{param label: 'Unstyled' /}
+	{param style: 'unstyled' /}
+	{param type: 'button' /}
+{/call}
+```
 
 ### Disabled
 
@@ -96,6 +161,41 @@ weight: 100
 <button class="btn btn-dark" disabled type="button">Dark</button>
 <button class="btn btn-link" disabled type="button">Link</button>
 <button class="btn btn-unstyled" disabled type="button">Unstyled</button>
+```
+```soy
+{call ClayButton.render}
+	{param disabled: true /}
+	{param label: 'Primary' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param disabled: true /}
+	{param label: 'Secondary' /}
+	{param style: 'secondary' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param disabled: true /}
+	{param label: 'Link' /}
+	{param style: 'link' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param disabled: true /}
+	{param label: 'Borderless' /}
+	{param style: 'borderless' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param disabled: true /}
+	{param label: 'Unstyled' /}
+	{param style: 'unstyled' /}
+	{param type: 'button' /}
+{/call}
 ```
 
 ### Anchor and Input Elements as Buttons
@@ -254,6 +354,41 @@ weight: 100
 <button class="btn btn-monospaced btn-dark" type="button">H</button>
 <button class="btn btn-monospaced btn-link" type="button">I</button>
 ```
+```soy
+{call ClayButton.render}
+	{param elementClasses: 'btn-monospaced' /}
+	{param label: 'Primary' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param elementClasses: 'btn-monospaced' /}
+	{param label: 'Secondary' /}
+	{param style: 'secondary' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param elementClasses: 'btn-monospaced' /}
+	{param label: 'Link' /}
+	{param style: 'link' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param elementClasses: 'btn-monospaced' /}
+	{param label: 'Borderless' /}
+	{param style: 'borderless' /}
+	{param type: 'button' /}
+{/call}
+
+{call ClayButton.render}
+	{param elementClasses: 'btn-monospaced' /}
+	{param label: 'Unstyled' /}
+	{param style: 'unstyled' /}
+	{param type: 'button' /}
+{/call}
+```
 
 </article>
 
@@ -317,6 +452,27 @@ weight: 100
 	</div>
 </div>
 ```
+```soy
+{call ClayDropdown.render}
+	{param items: [
+		[
+			'label': 'Action',
+			'url': '#1'
+		],
+		[
+			'separator': true,
+			'type': 'group'
+		],
+		[
+			'label': 'Scope',
+			'url': '#1'
+		]
+	] /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param triggerLabel: 'Primary' /}
+	{param triggerStyle: 'primary' /}
+{/call}
+```
 
 </article>
 
@@ -334,6 +490,16 @@ weight: 100
 <button class="btn btn-secondary" type="button">Default</button>
 <button class="btn btn-secondary btn-lg" type="button">Large</button>
 ```
+```soy
+{call ClayButton.render}
+	{param label: 'Small' /}
+	{param size: 'sm' /}
+{/call}
+
+{call ClayButton.render}
+	{param label: 'Default' /}
+{/call}
+```
 
 <button class="btn btn-monospaced btn-secondary btn-sm" type="button">
 	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-blogs">
@@ -374,6 +540,24 @@ weight: 100
 	XL
 </button>
 ```
+```soy
+{call ClayButton.render}
+	{param icon: [
+			'monospaced': true,
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'blogs'
+	] /}
+	{param size: 'sm' /}
+{/call}
+
+{call ClayButton.render}
+	{param icon: [
+			'monospaced': true,
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'plus'
+	] /}
+{/call}
+```
 
 <button class="btn btn-block btn-secondary btn-sm" type="button">Small Block Level Button</button>
 <button class="btn btn-block btn-secondary" type="button">Normal Block Level Button</button>
@@ -383,6 +567,18 @@ weight: 100
 <button class="btn btn-block btn-secondary btn-sm" type="button">Small Block Level Button</button>
 <button class="btn btn-block btn-secondary" type="button">Normal Block Level Button</button>
 <button class="btn btn-block btn-lg btn-secondary" type="button">Large Block Level Button</button>
+```
+```soy
+{call ClayButton.render}
+	{param block: true /}
+	{param label: 'Small Block Level Button' /}
+	{param size: 'sm' /}
+{/call}
+
+{call ClayButton.render}
+	{param block: true /}
+	{param label: 'Normal Block Level Button' /}
+{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/buttons.md
+++ b/src/pages/docs/components/buttons.md
@@ -20,7 +20,7 @@ weight: 100
 <button class="btn btn-link" type="button">Link</button>
 <button class="btn btn-unstyled" type="button">Unstyled</button>
 
-```xml
+```text/html
 <button class="btn btn-primary" type="button">Primary</button>
 <button class="btn btn-secondary" type="button">Secondary</button>
 <button class="btn btn-info" type="button">Info</button>
@@ -89,7 +89,7 @@ weight: 100
 <button class="active btn btn-link" type="button">Link</button>
 <button class="active btn btn-unstyled" type="button">Unstyled</button>
 
-```xml
+```text/html
 <button class="active btn btn-primary" type="button">Primary</button>
 <button class="active btn btn-secondary" type="button">Secondary</button>
 <button class="active btn btn-info" type="button">Info</button>
@@ -150,7 +150,7 @@ weight: 100
 <button class="btn btn-link" disabled type="button">Link</button>
 <button class="btn btn-unstyled" disabled type="button">Unstyled</button>
 
-```xml
+```text/html
 <button class="btn btn-primary" disabled type="button">Primary</button>
 <button class="btn btn-secondary" disabled type="button">Secondary</button>
 <button class="btn btn-info" disabled type="button">Info</button>
@@ -210,7 +210,7 @@ weight: 100
 <a class="btn btn-dark" href="#1" role="button">Anchor</a>
 <a class="btn btn-link" href="#1" role="button">Anchor</a>
 
-```xml
+```text/html
 <input class="btn btn-primary" type="button" value="Input" />
 <a class="btn btn-secondary" href="#1" role="button">Anchor</a>
 <input class="btn btn-info" type="submit" value="Submit" />
@@ -238,7 +238,7 @@ weight: 100
 <button class="btn btn-outline-light" type="button">Light</button>
 <button class="btn btn-outline-dark" type="button">Dark</button>
 
-```xml
+```text/html
 <button class="btn btn-outline-primary" type="button">Primary</button>
 <button class="btn btn-outline-secondary" type="button">Secondary</button>
 <button class="btn btn-outline-info" type="button">Info</button>
@@ -271,7 +271,7 @@ weight: 100
 <button class="active btn btn-outline-light" type="button">Light</button>
 <button class="active btn btn-outline-dark" type="button">Dark</button>
 
-```xml
+```text/html
 <button class="active btn btn-outline-primary" type="button">Primary</button>
 <button class="active btn btn-outline-secondary" type="button">Secondary</button>
 <button class="active btn btn-outline-info" type="button">Info</button>
@@ -293,7 +293,7 @@ weight: 100
 <button class="btn btn-outline-light" disabled type="button">Light</button>
 <button class="btn btn-outline-dark" disabled type="button">Dark</button>
 
-```xml
+```text/html
 <button class="btn btn-outline-primary" disabled type="button">Primary</button>
 <button class="btn btn-outline-secondary" disabled type="button">Secondary</button>
 <button class="btn btn-outline-info" disabled type="button">Info</button>
@@ -315,7 +315,7 @@ weight: 100
 <a class="btn btn-outline-light" href="#1" role="button">Anchor</a>
 <a class="btn btn-outline-dark" href="#1" role="button">Anchor</a>
 
-```xml
+```text/html
 <input class="btn btn-outline-primary" type="button" value="Input" />
 <a class="btn btn-outline-secondary" href="#1" role="button">Anchor</a>
 <input class="btn btn-outline-info" type="submit" value="Submit" />
@@ -343,7 +343,7 @@ weight: 100
 <button class="btn btn-monospaced btn-dark" type="button">H</button>
 <button class="btn btn-monospaced btn-link" type="button">I</button>
 
-```xml
+```text/html
 <button class="btn btn-monospaced btn-primary" type="button">A</button>
 <button class="btn btn-monospaced btn-secondary" type="button">B</button>
 <button class="btn btn-monospaced btn-info" type="button">C</button>
@@ -424,7 +424,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="dropdown">
 	<button aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" type="button">
 		Primary
@@ -485,7 +485,7 @@ weight: 100
 <button class="btn btn-secondary" type="button">Default</button>
 <button class="btn btn-secondary btn-lg" type="button">Large</button>
 
-```xml
+```text/html
 <button class="btn btn-secondary btn-sm" type="button">Small</button>
 <button class="btn btn-secondary" type="button">Default</button>
 <button class="btn btn-secondary btn-lg" type="button">Large</button>
@@ -520,7 +520,7 @@ weight: 100
 	XL
 </button>
 
-```xml
+```text/html
 <button class="btn btn-monospaced btn-secondary btn-sm" type="button">
 	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-blogs">
 		<use xlink:href="/vendor/lexicon/icons.svg#blogs"></use>
@@ -563,7 +563,7 @@ weight: 100
 <button class="btn btn-block btn-secondary" type="button">Normal Block Level Button</button>
 <button class="btn btn-block btn-lg btn-secondary" type="button">Large Block Level Button</button>
 
-```xml
+```text/html
 <button class="btn btn-block btn-secondary btn-sm" type="button">Small Block Level Button</button>
 <button class="btn btn-block btn-secondary" type="button">Normal Block Level Button</button>
 <button class="btn btn-block btn-lg btn-secondary" type="button">Large Block Level Button</button>

--- a/src/pages/docs/components/cards.md
+++ b/src/pages/docs/components/cards.md
@@ -249,7 +249,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="card card-horizontal">
 	<div class="card-body">
 		<div class="card-row">
@@ -291,7 +291,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="card card-horizontal">
 	<div class="card-body">
 		<div class="card-row">
@@ -333,7 +333,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="card card-horizontal">
 	<div class="card-body">
 		<div class="card-row">
@@ -386,7 +386,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="card card-horizontal">
 	<div class="card-row">
 		<div class="justify-content-start flex-col flex-col-expand">top</div>
@@ -421,7 +421,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="card card-horizontal">
 	<div class="card-row">
 		<div class="flex-col">
@@ -473,7 +473,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="card card-horizontal rounded">
 	<div class="card-row">
 		<div class="flex-col flex-col-expand">flex-col-expand</div>
@@ -553,7 +553,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="card card-horizontal">
 	<div class="card-row">
 		<div class="flex-col flex-col-expand">
@@ -749,7 +749,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-check form-check-card form-check-top-left">
 	<label class="form-check-label">
 		<input class="form-check-input" type="checkbox">
@@ -972,7 +972,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-check form-check-card form-check-top-left">
 	<div class="custom-control custom-radio">
 		<label>
@@ -1153,7 +1153,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="active form-check form-check-card form-check-top-left">
 	<label class="form-check-label">
 		<input checked class="form-check-input" type="checkbox">
@@ -1331,7 +1331,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="active form-check form-check-card form-check-top-left">
 	<label class="form-check-label">
 		<input checked class="form-check-input" name="cardRadios1" type="radio" value="cardOption1">

--- a/src/pages/docs/components/dropdowns.md
+++ b/src/pages/docs/components/dropdowns.md
@@ -76,6 +76,38 @@ weight: 100
 	</div>
 </div>
 ```
+```soy
+{call ClayActionsDropdown.render}
+	{param items: [
+			[
+				'label': 'Download',
+				'url': '#1'
+			],
+			[
+				'label': 'Edit',
+				'url': '#1'
+			],
+			[
+				'label': 'Move',
+				'url': '#1'
+			],
+			[
+				'label': 'Checkout',
+				'url': '#1'
+			],
+			[
+				'label': 'Permissions',
+				'url': '#1'
+			],
+			[
+				'label': 'Move to Recycle Bin',
+				'url': '#1'
+			],
+	] /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param triggerLabel: 'Trigger' /}
+{/call}
+```
 
 </article>
 
@@ -194,6 +226,70 @@ weight: 100
 	<a class="dropdown-item" href="#">Status</a>
 </div>
 ```
+```soy
+{call ClayDropdown.render}
+	{param items: [
+			[
+				'label': 'Filter By',
+				'items': [
+					[
+						'checked': true,
+						'label': 'Selected Option',
+						'inputValue': '1',
+						'type': 'checkbox'
+					],
+					[
+						'label': 'Normal option',
+						'inputValue': '2',
+						'type': 'checkbox'
+					],
+					[
+						'disabled': true,
+						'label': 'Disabled option',
+						'inputValue': '3',
+						'type': 'checkbox'
+					]
+				],
+				'type': 'group'
+			]
+	] /}
+	{param searchable: true /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param triggerLabel: 'Trigger Label' /}
+{/call}
+
+{call ClayDropdown.render}
+	{param button: [
+			'label': 'Done',
+			'style': 'primary'
+	] /}
+	{param items: [
+			[
+				'label': 'Order By',
+				'items': [
+					[
+						'checked': true,
+						'label': 'Selected Option',
+						'inputValue': '1',
+					],
+					[
+						'label': 'Normal option',
+						'inputValue': '2',
+					],
+					[
+						'disabled': true,
+						'label': 'Disabled option',
+						'inputValue': '3',
+					]
+				],
+				'inputName': 'item1radio',
+				'type': 'radiogroup'
+			]
+	] /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param triggerLabel: 'Trigger Label' /}
+{/call}
+```
 
 </article>
 
@@ -271,6 +367,46 @@ weight: 100
 	<div class="dropdown-caption">Dropdown Caption</div>
 </div>
 ```
+```soy
+{param ClayDropdownBase.render}
+	{param caption: 'Dropdown Caption' /}
+	{param items: [
+			[
+				'label': 'Dropdown header',
+				'items': [
+					[
+						'label': 'Ticket Buyer Information',
+						'indicatorSymbol': 'check',
+						'url': '#1'
+					],
+					[
+						'label': 'Attendee Information',
+						'indicatorSymbol': 'check',
+						'url': '#1'
+					],
+					[
+						'label': 'Seat Assignment',
+						'indicatorSymbol': 'check',
+						'url': '#1'
+					],
+					[
+						'active': true,
+						'label': 'Dinner Preference',
+						'url': '#1'
+					],
+					[
+						'label': 'Submit Payment',
+						'url': '#1'
+					],
+				],
+				'type': 'group'
+			]
+	] /}
+	{param indicatorsPosition: 'left' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param triggerLabel: 'Trigger label' /}
+{/param}
+```
 
 ### Dropdown Menu Indicator End
 
@@ -342,6 +478,47 @@ weight: 100
 	<a class="dropdown-item" href="#1">Step 05</a>
 	<div class="dropdown-caption">Showing 190,722 of 192,842 Things</div>
 </div>
+```
+```
+{param ClayDropdownBase.render}
+	{param caption: 'Showing 190,722 of 192,842 Things' /}
+	{param items: [
+			[
+				'label': 'Order by',
+				'items': [
+					[
+						'active': true,
+						'label': 'Step 01',
+						'indicatorSymbol': 'check',
+						'url': '#1'
+					],
+					[
+						'disabled': true,
+						'label': 'Step 02',
+						'indicatorSymbol': 'check',
+						'url': '#1'
+					],
+					[
+						'label': 'Step 03',
+						'indicatorSymbol': 'times',
+						'url': '#1'
+					],
+					[
+						'label': 'Step 04',
+						'url': '#1'
+					],
+					[
+						'label': 'Step 05',
+						'url': '#1'
+					],
+				],
+				'type': 'group'
+			]
+	] /}
+	{param indicatorsPosition: 'right' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param triggerLabel: 'Trigger label' /}
+{/param}
 ```
 
 </article>
@@ -434,6 +611,58 @@ weight: 100
 	<div class="dropdown-divider"></div>
 	<a class="dropdown-item" href="#">Scope</a>
 </div>
+```
+```soy
+{call ClayDropdownBase.render}
+	{param button: [
+			'label': 'More',
+			'style': 'primary'
+	] /}
+	{param caption: 'Showing 7 of 203 Structures' /}
+	{param helpText: 'You can customize this menu or see all you have by pressing "more".' /}
+	{param items: [
+		[
+			'label': 'Favorites',
+			'items': [
+				[
+					'label': 'D Structure',
+					'url': '#1'
+				],
+				[
+					'label': 'F Structure',
+					'url': '#1'
+				],
+				[
+					'disabled': true,
+					'label': 'H Structure',
+					'url': '#1'
+				],
+				[
+					'label': 'J Structure',
+					'url': '#1'
+				],
+				[
+					'label': 'L Structure',
+					'url': '#1'
+				],
+				[
+					'label': 'M Structure',
+					'url': '#1'
+				],
+				[
+					'label': 'P Structure',
+					'url': '#1'
+				],
+				[
+					'label': 'Q Structure',
+					'url': '#1'
+				]
+			],
+			'type': 'group'
+		]
+	] /}
+	{param triggerLabel: 'Trigger Label' /}
+{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/dropdowns.md
+++ b/src/pages/docs/components/dropdowns.md
@@ -59,7 +59,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="dropdown dropdown-action">
 	<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
 		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-ellipsis-v">
@@ -183,7 +183,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-labelledby="" class="dropdown-menu">
 	<div class="dropdown-subheader">Order by</div>
 	<a class="active dropdown-item" href="#">Author</a>
@@ -237,7 +237,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-labelledby="" class="dropdown-menu dropdown-menu-indicator-start">
 	<div class="dropdown-header">Dropdown Header</div>
 	<div class="dropdown-divider"></div>
@@ -309,7 +309,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-labelledby="" class="dropdown-menu dropdown-menu-indicator-end">
 	<div class="dropdown-header">Folder</div>
 	<div class="dropdown-divider"></div>
@@ -409,7 +409,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-labelledby="" class="dropdown-menu">
 	<div class="dropdown-header">Dropdown Header</div>
 	<div class="inline-scroller">
@@ -485,7 +485,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-labelledby="" class="dropdown-wide dropdown-wide-container">
 	<div class="dropdown-menu">
 		<div class="row">
@@ -553,7 +553,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-labelledby="" class="dropdown-menu dropdown-menu-horizontal">
 	<div class="dropdown-subheader">Order by</div>
 	<a class="active dropdown-item" href="#1">

--- a/src/pages/docs/components/dropdowns.md
+++ b/src/pages/docs/components/dropdowns.md
@@ -76,38 +76,6 @@ weight: 100
 	</div>
 </div>
 ```
-```soy
-{call ClayActionsDropdown.render}
-	{param items: [
-			[
-				'label': 'Download',
-				'url': '#1'
-			],
-			[
-				'label': 'Edit',
-				'url': '#1'
-			],
-			[
-				'label': 'Move',
-				'url': '#1'
-			],
-			[
-				'label': 'Checkout',
-				'url': '#1'
-			],
-			[
-				'label': 'Permissions',
-				'url': '#1'
-			],
-			[
-				'label': 'Move to Recycle Bin',
-				'url': '#1'
-			],
-	] /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param triggerLabel: 'Trigger' /}
-{/call}
-```
 
 </article>
 
@@ -226,70 +194,6 @@ weight: 100
 	<a class="dropdown-item" href="#">Status</a>
 </div>
 ```
-```soy
-{call ClayDropdown.render}
-	{param items: [
-			[
-				'label': 'Filter By',
-				'items': [
-					[
-						'checked': true,
-						'label': 'Selected Option',
-						'inputValue': '1',
-						'type': 'checkbox'
-					],
-					[
-						'label': 'Normal option',
-						'inputValue': '2',
-						'type': 'checkbox'
-					],
-					[
-						'disabled': true,
-						'label': 'Disabled option',
-						'inputValue': '3',
-						'type': 'checkbox'
-					]
-				],
-				'type': 'group'
-			]
-	] /}
-	{param searchable: true /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param triggerLabel: 'Trigger Label' /}
-{/call}
-
-{call ClayDropdown.render}
-	{param button: [
-			'label': 'Done',
-			'style': 'primary'
-	] /}
-	{param items: [
-			[
-				'label': 'Order By',
-				'items': [
-					[
-						'checked': true,
-						'label': 'Selected Option',
-						'inputValue': '1',
-					],
-					[
-						'label': 'Normal option',
-						'inputValue': '2',
-					],
-					[
-						'disabled': true,
-						'label': 'Disabled option',
-						'inputValue': '3',
-					]
-				],
-				'inputName': 'item1radio',
-				'type': 'radiogroup'
-			]
-	] /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param triggerLabel: 'Trigger Label' /}
-{/call}
-```
 
 </article>
 
@@ -367,46 +271,6 @@ weight: 100
 	<div class="dropdown-caption">Dropdown Caption</div>
 </div>
 ```
-```soy
-{param ClayDropdownBase.render}
-	{param caption: 'Dropdown Caption' /}
-	{param items: [
-			[
-				'label': 'Dropdown header',
-				'items': [
-					[
-						'label': 'Ticket Buyer Information',
-						'indicatorSymbol': 'check',
-						'url': '#1'
-					],
-					[
-						'label': 'Attendee Information',
-						'indicatorSymbol': 'check',
-						'url': '#1'
-					],
-					[
-						'label': 'Seat Assignment',
-						'indicatorSymbol': 'check',
-						'url': '#1'
-					],
-					[
-						'active': true,
-						'label': 'Dinner Preference',
-						'url': '#1'
-					],
-					[
-						'label': 'Submit Payment',
-						'url': '#1'
-					],
-				],
-				'type': 'group'
-			]
-	] /}
-	{param indicatorsPosition: 'left' /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param triggerLabel: 'Trigger label' /}
-{/param}
-```
 
 ### Dropdown Menu Indicator End
 
@@ -478,47 +342,6 @@ weight: 100
 	<a class="dropdown-item" href="#1">Step 05</a>
 	<div class="dropdown-caption">Showing 190,722 of 192,842 Things</div>
 </div>
-```
-```
-{param ClayDropdownBase.render}
-	{param caption: 'Showing 190,722 of 192,842 Things' /}
-	{param items: [
-			[
-				'label': 'Order by',
-				'items': [
-					[
-						'active': true,
-						'label': 'Step 01',
-						'indicatorSymbol': 'check',
-						'url': '#1'
-					],
-					[
-						'disabled': true,
-						'label': 'Step 02',
-						'indicatorSymbol': 'check',
-						'url': '#1'
-					],
-					[
-						'label': 'Step 03',
-						'indicatorSymbol': 'times',
-						'url': '#1'
-					],
-					[
-						'label': 'Step 04',
-						'url': '#1'
-					],
-					[
-						'label': 'Step 05',
-						'url': '#1'
-					],
-				],
-				'type': 'group'
-			]
-	] /}
-	{param indicatorsPosition: 'right' /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param triggerLabel: 'Trigger label' /}
-{/param}
 ```
 
 </article>
@@ -611,58 +434,6 @@ weight: 100
 	<div class="dropdown-divider"></div>
 	<a class="dropdown-item" href="#">Scope</a>
 </div>
-```
-```soy
-{call ClayDropdownBase.render}
-	{param button: [
-			'label': 'More',
-			'style': 'primary'
-	] /}
-	{param caption: 'Showing 7 of 203 Structures' /}
-	{param helpText: 'You can customize this menu or see all you have by pressing "more".' /}
-	{param items: [
-		[
-			'label': 'Favorites',
-			'items': [
-				[
-					'label': 'D Structure',
-					'url': '#1'
-				],
-				[
-					'label': 'F Structure',
-					'url': '#1'
-				],
-				[
-					'disabled': true,
-					'label': 'H Structure',
-					'url': '#1'
-				],
-				[
-					'label': 'J Structure',
-					'url': '#1'
-				],
-				[
-					'label': 'L Structure',
-					'url': '#1'
-				],
-				[
-					'label': 'M Structure',
-					'url': '#1'
-				],
-				[
-					'label': 'P Structure',
-					'url': '#1'
-				],
-				[
-					'label': 'Q Structure',
-					'url': '#1'
-				]
-			],
-			'type': 'group'
-		]
-	] /}
-	{param triggerLabel: 'Trigger Label' /}
-{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/form_custom.md
+++ b/src/pages/docs/components/form_custom.md
@@ -64,7 +64,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label for="customFile1">Attach File</label>
 	<div class="input-group">
@@ -169,7 +169,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="custom-control custom-checkbox">
 	<label>
 		<input class="custom-control-input" type="checkbox">
@@ -275,7 +275,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="custom-control custom-radio">
 	<label>
 		<input checked class="custom-control-input" id="radio1" name="radio" type="radio">
@@ -331,7 +331,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="custom-control custom-control-inline custom-radio">
 	<label>
 		<input class="custom-control-input" disabled id="radioStacked3" name="radio-stacked" type="radio">
@@ -382,7 +382,7 @@ weight: 100
 	</select>
 </div>
 
-```xml
+```text/html
 <select class="custom-select">
 	<option selected="">Open this select menu</option>
 	<option value="1">One</option>
@@ -410,7 +410,7 @@ weight: 100
 	</label>
 </div>
 
-```xml
+```text/html
 <label class="custom-file">
 	<input class="custom-file-input" type="file">
 	<span class="custom-file-control"></span>

--- a/src/pages/docs/components/form_custom.md
+++ b/src/pages/docs/components/form_custom.md
@@ -292,6 +292,20 @@ weight: 100
 	</label>
 </div>
 ```
+```soy
+{call ClayRadio.render}
+	{param checked: true /}
+	{param id: 'radio1' /}
+	{param label: 'Toggle this custom radio' /}
+	{param name: 'radio' /}
+{/call}
+
+{call ClayRadio.render}
+	{param id: 'radio2' /}
+	{param label: 'Or toggle this other custom radio' /}
+	{param name: 'radio' /}
+{/call}
+```
 
 </article>
 
@@ -332,6 +346,20 @@ weight: 100
 		<span class="custom-control-description">Or toggle this other custom radio</span>
 	</label>
 </div>
+```
+```soy
+{call ClayRadio.render}
+	{param disabled: true /}
+	{param id: 'radioStacked3' /}
+	{param label: 'Toggle this custom radio' /}
+	{param name: 'radio-stacked' /}
+{/call}
+
+{call ClayRadio.render}
+	{param id: 'radioStacked4' /}
+	{param label: 'Or toggle this other custom radio' /}
+	{param name: 'radio-stacked' /}
+{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/form_custom.md
+++ b/src/pages/docs/components/form_custom.md
@@ -218,6 +218,38 @@ weight: 100
 	</label>
 </div>
 ```
+```soy
+{call ClayCheckbox.render}
+	{param label: 'Unchecked' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param checked: true /}
+	{param label: 'Checked' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param indeterminate: true /}
+	{param label: 'Indeterminate' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param disabled: true /}
+	{param label: 'Unchecked disabled' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param checked: true /}
+	{param disabled: true /}
+	{param label: 'Checked disabled' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param disabled: true /}
+	{param indeterminate: true /}
+	{param label: 'Indeterminate disabled' /}
+{/call}
+```
 
 </article>
 

--- a/src/pages/docs/components/form_elements.md
+++ b/src/pages/docs/components/form_elements.md
@@ -33,7 +33,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label>
 		Default text input
@@ -100,7 +100,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-check">
 	<label class="form-check-label">
 		<input class="form-check-input" type="checkbox" value="">
@@ -210,7 +210,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-check">
 	<label class="form-check-label">
 		<input class="form-check-input" type="radio" value="">
@@ -308,7 +308,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <label for="regularSelectElement">Regular Select Element</label>
 <select class="form-control" id="regularSelectElement">
 	<option>Sample 1</option>
@@ -390,7 +390,7 @@ weight: 100
 	<input id="inputFile" type="file">
 </div>
 
-```xml
+```text/html
 <label class="sr-only" for="inputFile">FILE UPLOAD</label>
 <input id="inputFile" type="file">
 ```
@@ -441,7 +441,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <label class="disabled" for="disabledTextInput">Text Input</label>
 <input class="form-control" disabled id="disabledTextInput" placeholder="Placeholder" type="text" value="Plunger pot, extra siphon latte">
 
@@ -567,7 +567,7 @@ weight: 100
 	</form>
 </div>
 
-```xml
+```text/html
 <form>
 	<fieldset disabled>
 		<div class="form-group">
@@ -601,7 +601,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <label for="readonlyTextInput">Text Input (Read Only)</label>
 <input class="form-control" id="readonlyTextInput" placeholder="Placeholder" readonly type="text" value="Con panna aroma, pumpkin spice to go, wings, aromatic single shot, aged single shot to go extraction java.">
 
@@ -631,7 +631,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <label for="smallTextInput">Small text input</label>
 <input class="form-control form-control-sm" id="smallTextInput" placeholder="Placeholder" type="text">
 
@@ -668,7 +668,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label for="firstNameInput">First Name</label>
 	<input class="form-control" id="firstNameInput" placeholder="First Name" type="text">
@@ -702,7 +702,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-inline">
 	<label for="formInlineInput">Form Inline</label>
 	<input class="form-control" id="formInlineInput" type="text">
@@ -775,7 +775,7 @@ weight: 100
 	<a class="btn btn-danger" href="#1">Clear</a>
 </div>
 
-```xml
+```text/html
 <div class="form-inline form-inline-autofit">
 	<div class="form-inline-group">
 		<label for="formInlineAutofitTextInput1">Form Inline Autofit</label>
@@ -833,7 +833,7 @@ weight: 100
 	</form>
 </div>
 
-```xml
+```text/html
 <style>
 	@media (min-width: 576px) {
 		.my-custom-form label {

--- a/src/pages/docs/components/form_elements.md
+++ b/src/pages/docs/components/form_elements.md
@@ -329,6 +329,54 @@ weight: 100
 	<option>Sample 8</option>
 </select>
 ```
+```soy
+{call ClaySelect.render}
+	{param id: 'regularSelectElement' /}
+	{param label: 'Regular Select Element' /}
+	{param options: [
+		[
+			'label': 'Sample 1',
+			'value': '1'
+		],
+		[
+			'label': 'Sample 2',
+			'value': '2'
+		],
+		[
+			'label': 'Sample 3',
+			'value': '3'
+		],
+		[
+			'label': 'Sample 4',
+			'value': '4'
+		],
+	] /}
+{/call}
+
+{call ClaySelect.render}
+	{param id: 'multipleSelectOptionsSelectElement' /}
+	{param label: 'Select Element with Multiple Select Options' /}
+	{param multiple: true /}
+	{param options: [
+		[
+			'label': 'Sample 1',
+			'value': '1'
+		],
+		[
+			'label': 'Sample 2',
+			'value': '2'
+		],
+		[
+			'label': 'Sample 3',
+			'value': '3'
+		],
+		[
+			'label': 'Sample 4',
+			'value': '4'
+		],
+	] /}
+{/call}
+```
 
 </article>
 
@@ -422,6 +470,56 @@ weight: 100
 	<option>Sample 7</option>
 	<option>Sample 8</option>
 </select>
+```
+```soy
+{call ClaySelect.render}
+	{param disabled: true /}
+	{param id: 'disabledSelectElement' /}
+	{param label: 'Select Element' /}
+	{param options: [
+		[
+			'label': 'Sample 1',
+			'value': '1'
+		],
+		[
+			'label': 'Sample 2',
+			'value': '2'
+		],
+		[
+			'label': 'Sample 3',
+			'value': '3'
+		],
+		[
+			'label': 'Sample 4',
+			'value': '4'
+		],
+	] /}
+{/call}
+
+{call ClaySelect.render}
+	{param disabled: true /}
+	{param id: 'disabledSelectElementMulti' /}
+	{param label: 'Select Element with Multiple Select Options' /}
+	{param multiple: true /}
+	{param options: [
+		[
+			'label': 'Sample 1',
+			'value': '1'
+		],
+		[
+			'label': 'Sample 2',
+			'value': '2'
+		],
+		[
+			'label': 'Sample 3',
+			'value': '3'
+		],
+		[
+			'label': 'Sample 4',
+			'value': '4'
+		],
+	] /}
+{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/form_elements.md
+++ b/src/pages/docs/components/form_elements.md
@@ -132,6 +132,41 @@ weight: 100
 	</label>
 </div>
 ```
+```soy
+{call ClayCheckbox.render}
+	{param hideLabel: true /}
+	{param label: 'Hidden Label Checkbox' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param label: 'Label' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param disabled: true /}
+	{param label: 'Disabled Check Box' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param disabled: true /}
+	{param label: 'Label' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param inline: true /}
+	{param label: 'Inline 1' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param inline: true /}
+	{param label: 'Inline 2' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param inline: true /}
+	{param label: 'Inline 3' /}
+{/call}
+```
 
 </article>
 

--- a/src/pages/docs/components/form_elements.md
+++ b/src/pages/docs/components/form_elements.md
@@ -239,6 +239,42 @@ weight: 100
 	</label>
 </div>
 ```
+```soy
+{call ClayRadio.render}
+	{param hideLabel: true /}
+	{param label: 'Hidden Label Radio' /}
+{/call}
+
+{call ClayRadio.render}
+	{param label: 'Label' /}
+{/call}
+
+{call ClayRadio.render}
+	{param disabled: true /}
+	{param label: 'Disabled Radio Button' /}
+{/call}
+
+{call ClayRadio.render}
+	{param inline: true /}
+	{param label: '1' /}
+	{param name: 'inline-radio' /}
+	{param value: 'option1' /}
+{/call}
+
+{call ClayRadio.render}
+	{param inline: true /}
+	{param label: '2' /}
+	{param name: 'inline-radio' /}
+	{param value: 'option2' /}
+{/call}
+
+{call ClayRadio.render}
+	{param inline: true /}
+	{param label: '3' /}
+	{param name: 'inline-radio' /}
+	{param value: 'option3' /}
+{/call}
+```
 
 </article>
 

--- a/src/pages/docs/components/form_elements_input_groups.md
+++ b/src/pages/docs/components/form_elements_input_groups.md
@@ -39,7 +39,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<div class="input-group">
 		<span class="input-group-addon" id="basicAddon1">@</span>
@@ -104,7 +104,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="input-group input-group-sm">
 	<span class="input-group-addon input-group-constrain" id="inputGroupConstrain01">
 		<span class="input-group-constrain-text">https://web.liferay.com/community/forums/-/message_boards/category/72632049</span>
@@ -233,7 +233,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="input-group">
 	<span class="input-group-btn">
 		<button class="btn btn-secondary" type="button">Search</button>
@@ -407,7 +407,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label for="">Custom Checkbox</label>
 	<div class="input-group input-group-secondary">
@@ -455,7 +455,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label for="inputGroupTransparent">
 		Label
@@ -581,7 +581,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="input-group input-group-lg">
 	<span class="input-group-addon">$</span>
 	<input aria-label="Amount (to the nearest dollar)" class="form-control" type="text">
@@ -678,7 +678,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<div class="input-group input-group-inset">
 		<div class="input-group-input">

--- a/src/pages/docs/components/form_elements_validation.md
+++ b/src/pages/docs/components/form_elements_validation.md
@@ -60,7 +60,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="form-group has-error">
 	<label for="inputError1">
 		has-error
@@ -160,7 +160,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="has-error">
 	<div class="custom-control custom-checkbox">
 		<label>
@@ -260,7 +260,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="has-error">
 	<div class="form-check">
 		<label class="form-check-label">
@@ -341,7 +341,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="has-error">
 	<div class="form-group">
 		<label for="selectElementError">
@@ -418,7 +418,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="has-error">
 	<div class="form-group">
 		<label for="multipleSelectElementError">
@@ -483,7 +483,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="has-error">
 	<div class="form-group">
 		<label for="readonlyError">Text Input (Read Only) with Error</label>
@@ -659,7 +659,7 @@ weight: 100
 	</form>
 </div>
 
-```xml
+```text/html
 <form class="was-validated">
 	<div class="form-group">
 		<label for="formValidationFirstName">

--- a/src/pages/docs/components/icons-lexicon.md
+++ b/src/pages/docs/components/icons-lexicon.md
@@ -15,7 +15,7 @@ weight: 100
 
 > We use SVG elements that link to an SVG sprite, like so:
 
-```xml
+```text/html
 <svg class="lexicon-icon">
 	<use xlink:href="path/to/icons.svg#add-column" />
 </svg>

--- a/src/pages/docs/components/icons-lexicon.md
+++ b/src/pages/docs/components/icons-lexicon.md
@@ -20,6 +20,18 @@ weight: 100
 	<use xlink:href="path/to/icons.svg#add-column" />
 </svg>
 ```
+```soy
+{call ClayIcon.render}
+	{param spritemap: 'path/to/icons.svg' /}
+	{param symbol: 'add-column' /}
+{/call}
+
+{call ClayIcon.render}
+	{param monospaced: true /}
+	{param spritemap: 'path/to/icons.svg' /}
+	{param symbol: 'add-column' /}
+{/call}
+```
 
 > Note that the ID after the # symbol is the ID of the icon to use, so if you wanted to use plus icon, you would do change the `href` to `path/to/icons.svg#plus`.
 

--- a/src/pages/docs/components/images_aspect_ratio.md
+++ b/src/pages/docs/components/images_aspect_ratio.md
@@ -57,7 +57,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="aspect-ratio">
 	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
 </div>
@@ -119,7 +119,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="aspect-ratio">
 	<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
 </div>
@@ -158,7 +158,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="aspect-ratio aspect-ratio-16-to-9">
 	<img alt="thumbnail" class=" aspect-ratio-item aspect-ratio-item-center aspect-ratio-item-middle" src="/images/thumbnail_hot_air_ballon.jpg">
 </div>
@@ -228,7 +228,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="aspect-ratio aspect-ratio-16-to-9">
 	<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="/images/liferay_logo_tagline.png">
 </div>
@@ -282,7 +282,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="aspect-ratio aspect-ratio-16-to-9 aspect-ratio-bg-cover" style="background-image: url(/images/thumbnail_hot_air_ballon.jpg);">
 </div>
 
@@ -323,7 +323,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="aspect-ratio aspect-ratio-16-to-9">
 	<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid">
 		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">

--- a/src/pages/docs/components/list_groups.md
+++ b/src/pages/docs/components/list_groups.md
@@ -124,7 +124,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="list-group show-dropdown-action-on-active">
 	<li class="list-group-item list-group-item-flex">
 		<div class="flex-col">
@@ -345,7 +345,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="list-group list-group-bordered show-dropdown-action-on-active">
 	<li class="list-group-item list-group-item-flex">
 		<div class="flex-col">
@@ -574,7 +574,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="list-group show-dropdown-action-on-active">
 	<li class="list-group-header">
 		<h3 class="list-group-header-title">List Group Header 1</h3>
@@ -782,7 +782,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="list-group list-group-unstyled">
 	<li class="list-group-header">
 		<h3 class="list-group-header-title">List Group Header 1</h3>
@@ -880,7 +880,7 @@ weight: 100
 	<a class="list-group-item list-group-item-action" href="#1">List Item 4</a>
 </div>
 
-```xml
+```text/html
 <div class="list-group">
 	<a class="list-group-item list-group-item-action" href="#1">List Item 1</a>
 	<a class="list-group-item list-group-item-action" href="#1">List Item 2</a>
@@ -906,7 +906,7 @@ weight: 100
 	<li class="list-group-item list-group-item-dark">List Item Dark</li>
 </ul>
 
-```xml
+```text/html
 <ul class="list-group">
 	<li class="list-group-item">List Item Normal</li>
 	<li class="list-group-item list-group-item-success">List Item Success</li>
@@ -950,7 +950,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="list-group">
 	<a class="list-group-item list-group-item-action" href="#1">List Item Action Normal</a>
 	<a class="list-group-item list-group-item-action list-group-item-success" href="#1">List Item Action Success</a>

--- a/src/pages/docs/components/management-bar.md
+++ b/src/pages/docs/components/management-bar.md
@@ -420,7 +420,7 @@ weight: 100
 	</div>
 </nav>
 
-```xml
+```text/html
 <nav class="management-bar navbar navbar-expand-md navbar-light">
 	<div class="container-fluid container-fluid-max-xl">
 		<ul class="navbar-nav">
@@ -694,7 +694,7 @@ weight: 100
 	</div>
 </nav>
 
-```xml
+```text/html
 <nav class="management-bar navbar navbar-expand-md navbar-light">
 	<div class="container-fluid container-fluid-max-xl">
 		<ul class="navbar-nav">

--- a/src/pages/docs/components/modals.md
+++ b/src/pages/docs/components/modals.md
@@ -39,7 +39,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <button class="btn btn-info" data-target="#lexSmallModal" data-toggle="modal">Small Modal</button>
 <div aria-labelledby="lexSmallModalLabel" class="fade modal" id="lexSmallModal" role="dialog" tabindex="-1">
 	<div class="modal-dialog modal-sm">
@@ -109,7 +109,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <button class="btn btn-info" data-target="#lexDefaultModal" data-toggle="modal">Default Modal</button>
 <div aria-labelledby="lexDefaultModalLabel" class="fade modal" id="lexDefaultModal" role="dialog" tabindex="-1">
 	<div class="modal-dialog">
@@ -182,7 +182,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <button class="btn btn-info" data-target="#lexLargeModal" data-toggle="modal">Large Modal</button>
 <div aria-labelledby="lexLargeModalLabel" class="fade modal" id="lexLargeModal" role="dialog" tabindex="-1">
 	<div class="modal-dialog modal-lg">
@@ -273,7 +273,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <button class="btn btn-info" data-target="#claySmallModalInlineScroller" data-toggle="modal">Small Modal Inline Scroller</button>
 <div aria-labelledby="claySmallModalInlineScrollerLabel" class="fade modal" id="claySmallModalInlineScroller" role="dialog" tabindex="-1">
 	<div class="modal-dialog modal-sm">
@@ -448,7 +448,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <button class="btn btn-info" data-target="#lexFullScreenModal" data-toggle="modal">Full Screen Modal</button>
 <div aria-labelledby="lexLargeModalLabel" class="fade modal" id="lexFullScreenModal" role="dialog" tabindex="-1">
 	<div class="modal-dialog modal-full-screen">
@@ -636,7 +636,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <button class="btn btn-info" data-target="#lexModalFullScreenSmDown" data-toggle="modal">Modal Full Screen Sm Down</button>
 <div aria-labelledby="lexModalFullScreenSmDownLabel" class="fade modal" id="lexModalFullScreenSmDown" role="dialog" tabindex="-1">
 	<div class="modal-dialog modal-full-screen-sm-down">
@@ -730,7 +730,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="alert alert-warning">In mobile safari (iOS 8.3), any content inside an iframe that triggers a browser reflow will cause the iframe to scroll to the top.</div>
 
 <button class="btn btn-info" data-target="#lexFullScreenModalIframe" data-toggle="modal">Full Screen Modal Iframe</button>
@@ -910,7 +910,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <button class="btn btn-secondary" data-target="#clayModalInverse" data-toggle="modal">Modal Inverse</button>
 		<div aria-labelledby="clayModalInverseLabel" class="fade modal" id="clayModalInverse" role="dialog" tabindex="-1">
 			<div class="modal-dialog modal-full-screen-sm-down modal-inverse">

--- a/src/pages/docs/components/multi_step_nav.md
+++ b/src/pages/docs/components/multi_step_nav.md
@@ -50,7 +50,7 @@ weight: 100
 	</ol>
 </div>
 
-```xml
+```text/html
 <ol class="multi-step-nav">
 	<li class="complete multi-step-item multi-step-item-expand">
 		<div class="multi-step-divider"></div>
@@ -187,7 +187,7 @@ weight: 100
 	</ol>
 </div>
 
-```xml
+```text/html
 <ol class="multi-step-nav multi-step-indicator-label-top">
 	<li class="complete multi-step-item multi-step-item-expand">
 		<div class="multi-step-divider"></div>
@@ -339,7 +339,7 @@ weight: 100
 	</ol>
 </div>
 
-```xml
+```text/html
 <ol class="multi-step-nav multi-step-indicator-label-bottom">
 	<li class="complete multi-step-item multi-step-item-expand">
 		<div class="multi-step-divider"></div>
@@ -451,7 +451,7 @@ weight: 100
 	</ol>
 </div>
 
-```xml
+```text/html
 <ol class="multi-step-nav multi-step-indicator-label-bottom multi-step-item-fixed-width">
 	<li class="complete multi-step-item multi-step-item-expand">
 		<div class="multi-step-title">Ticket Buyer Information</div>
@@ -574,7 +574,7 @@ weight: 100
 	</ol>
 </div>
 
-```xml
+```text/html
 <ol class="multi-step-nav multi-step-nav-collapse-sm multi-step-indicator-label-top">
 	<li class="complete multi-step-item multi-step-item-expand">
 		<div class="multi-step-divider"></div>
@@ -709,7 +709,7 @@ weight: 100
 	</ol>
 </div>
 
-```xml
+```text/html
 <ol class="multi-step-nav multi-step-nav-collapse-sm multi-step-indicator-label-bottom">
 	<li class="complete multi-step-item multi-step-item-expand">
 		<div class="multi-step-title">Ticket Buyer Information</div>

--- a/src/pages/docs/components/nav.md
+++ b/src/pages/docs/components/nav.md
@@ -16,7 +16,7 @@ weight: 100
 	<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
 </ul>
 
-```xml
+```text/html
 <ul class="nav">
 	<li class="nav-item"><a class="active nav-link" href="#1">Details</a></li>
 	<li class="nav-item"><a class="nav-link" href="#1">Catagorization</a></li>
@@ -45,7 +45,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="flex-column nav">
 	<li class="nav-item"><a class="active nav-link" href="#1">Details</a></li>
 	<li class="nav-item"><a class="nav-link" href="#1">Catagorization</a></li>
@@ -163,7 +163,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="nav nav-nested">
 	<li class="nav-item">
 		<a aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#navCollapse01">
@@ -362,7 +362,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="nav nav-nested-margins">
 	<li class="nav-item">
 		<a aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#navCollapse001">
@@ -472,7 +472,7 @@ weight: 100
 	<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
 </ul>
 
-```xml
+```text/html
 <ul class="nav nav-unstyled">
 	<li class="nav-item"><a class="active nav-link" href="#1">Details</a></li>
 	<li class="nav-item"><a class="nav-link" href="#1">Catagorization</a></li>

--- a/src/pages/docs/components/nav_pills.md
+++ b/src/pages/docs/components/nav_pills.md
@@ -33,7 +33,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="nav nav-pills">
 	<li class="nav-item"><a class="active nav-link" href="#1">Fields</a></li>
 	<li class="nav-item"><a class="nav-link" href="#1">Settings</a></li>
@@ -88,7 +88,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="nav nav-justified nav-pills">
 	<li class="nav-item"><a class="active nav-link" href="#1">Fields</a></li>
 	<li class="nav-item"><a class="nav-link" href="#1">Settings</a></li>
@@ -150,7 +150,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="flex-column nav nav-pills">
 	<li class="nav-item"><a class="active nav-link" href="#1">Fields</a></li>
 	<li class="nav-item">
@@ -238,7 +238,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="flex-column nav nav-nested nav-pills">
 	<li class="nav-item">
 		<a aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#navPillsCollapse01">

--- a/src/pages/docs/components/nav_tabs.md
+++ b/src/pages/docs/components/nav_tabs.md
@@ -56,7 +56,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="nav nav-tabs" role="tablist">
 	<li class="nav-item">
 		<a aria-controls="fields" aria-expanded="true" class="active nav-link" data-toggle="tab" href="#fields" id="fieldsTab" role="tab">Fields</a>
@@ -159,7 +159,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="nav nav-tabs" role="tablist">
 	<li class="nav-item">
 		<button aria-controls="buttonFields" aria-expanded="true" class="active btn btn-unstyled nav-link" data-target="#buttonFields" data-toggle="tab" id="buttonFieldsTab" role="tab" type="button">Fields</button>
@@ -262,7 +262,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="nav nav-justified nav-tabs" role="tablist">
 	<li class="nav-item">
 		<a aria-controls="navJustifiedFields" aria-expanded="true" class="active nav-link" data-toggle="tab" href="#navJustifiedFields" id="navJustifiedFieldsTab" role="tab">Fields</a>
@@ -367,7 +367,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="nav nav-tabs" role="tablist">
 	<li class="col-6 col-sm-3 nav-item">
 		<a aria-controls="navTabsGridFields" aria-expanded="true" class="active nav-link" data-toggle="tab" href="#navTabsGridFields" id="navTabsGridFieldsTab" role="tab">Fields</a>

--- a/src/pages/docs/components/nav_underline.md
+++ b/src/pages/docs/components/nav_underline.md
@@ -17,7 +17,7 @@ weight: 100
 	<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
 </ul>
 
-```xml
+```text/html
 <ul class="nav nav-underline">
 	<li class="nav-item"><a class="active nav-link" href="#1">Basic Information</a></li>
 	<li class="nav-item"><a class="nav-link" href="#1">Details</a></li>
@@ -81,7 +81,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="nav nav-underline" role="tablist">
 	<li class="nav-item">
 		<a aria-controls="navUnderlineFields" aria-expanded="true" class="active nav-link" data-toggle="tab" href="#navUnderlineFields" id="navUnderlineFieldsTab" role="tab">Fields</a>
@@ -184,7 +184,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <ul class="nav nav-underline" role="tablist">
 	<li class="nav-item">
 		<button aria-controls="buttonNavUnderlineFields" aria-expanded="true" class="active btn btn-unstyled nav-link" data-target="#buttonNavUnderlineFields" data-toggle="tab" id="buttonNavUnderlineFieldsTab" role="tab" type="button">Fields</button>

--- a/src/pages/docs/components/navbars.md
+++ b/src/pages/docs/components/navbars.md
@@ -208,7 +208,7 @@ weight: 100
 	</div>
 </nav>
 
-```xml
+```text/html
 <nav class="navbar navbar-expand-md navbar-light">
 	<a class="navbar-brand" href="#1">
 		<span class="navbar-text-truncate">Brand</span>
@@ -558,7 +558,7 @@ weight: 100
 	</div>
 </nav>
 
-```xml
+```text/html
 <nav class="navbar navbar-expand-md navbar-light">
 	<a class="navbar-brand" href="#1">
 		<span class="navbar-text-truncate">Brand</span>
@@ -874,7 +874,7 @@ weight: 100
 	</div>
 </nav>
 
-```xml
+```text/html
 <nav class="navbar navbar-collapse-absolute navbar-dark navbar-expand-md navbar-underline">
 	<button aria-label="Toggle navigation" class="collapsed navbar-toggler navbar-toggler-link" data-target="#navbar-collapse-001a" data-toggle="collapse" type="button">
 		<span class="navbar-text-truncate">Message Boards</span>
@@ -1040,7 +1040,7 @@ weight: 100
 	</ul>
 </nav>
 
-```xml
+```text/html
 <nav class="navbar navbar-expand navbar-light">
 	<ul class="navbar-nav">
 		<li class="nav-item">

--- a/src/pages/docs/components/navigation_bar.md
+++ b/src/pages/docs/components/navigation_bar.md
@@ -97,7 +97,7 @@ weight: 100
 	</div>
 </nav>
 
-```xml
+```text/html
 <nav class="navbar navigation-bar navbar-collapse-absolute navbar-dark navbar-expand-md navbar-underline">
 	<div class="container-fluid container-fluid-max-xl">
 		<button aria-expanded="false" aria-label="Toggle navigation" class="collapsed navbar-toggler navbar-toggler-link" data-target="#navigationBarCollapse01" data-toggle="collapse" type="button">

--- a/src/pages/docs/components/pagination.md
+++ b/src/pages/docs/components/pagination.md
@@ -65,7 +65,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="pagination">
 	<li class="disabled page-item">
 		<a class="page-link" href="#1">
@@ -190,7 +190,7 @@ weight: 100
 	</ul>
 </div>
 
-```xml
+```text/html
 <div class="pagination-bar">
 	<div class="dropdown pagination-items-per-page">
 		<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
@@ -323,7 +323,7 @@ weight: 100
 	</ul>
 </div>
 
-```xml
+```text/html
 <div class="pagination-bar pagination-sm">
 	<div class="dropdown pagination-items-per-page">
 		<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
@@ -447,7 +447,7 @@ weight: 100
 	</ul>
 </div>
 
-```xml
+```text/html
 <div class="pagination-bar">
 	<div class="dropdown pagination-items-per-page">
 		<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
@@ -571,7 +571,7 @@ weight: 100
 	</ul>
 </div>
 
-```xml
+```text/html
 <div class="pagination-bar pagination-lg">
 	<div class="dropdown pagination-items-per-page">
 		<a class="dropdown-toggle" data-toggle="dropdown" href="#1">

--- a/src/pages/docs/components/panels.md
+++ b/src/pages/docs/components/panels.md
@@ -26,7 +26,7 @@ weight: 100
 	<div class="panel-footer">Footer</div>
 </div>
 
-```xml
+```text/html
 <div class="panel panel-secondary">
 	<div class="panel-body">Body</div>
 </div>
@@ -106,7 +106,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="panel">
 	<div class="panel-header">panel</div>
 	<div class="panel-body">body</div>
@@ -192,7 +192,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-multiselectable="true" class="panel-group" id="accordion" role="tablist">
 	<div class="panel panel-secondary">
 		<a aria-controls="collapseOne" aria-expanded="true" class="panel-header panel-header-link" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" id="headingOne" role="tab">
@@ -361,7 +361,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div aria-multiselectable="true" class="panel-group" id="accordion03" role="tablist">
 	<div class="panel panel-secondary">
 		<a aria-controls="collapseTwo" aria-expanded="false" class="collapse-icon collapsed panel-header panel-header-link" data-parent="#accordion03" data-toggle="collapse" href="#accordion03CollapseTwo" id="accordion03HeadingTwo" role="tab">

--- a/src/pages/docs/components/popovers.md
+++ b/src/pages/docs/components/popovers.md
@@ -49,7 +49,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="popover bs-popover-top">
 	<div class="arrow"></div>
 	<div class="inline-scroller">
@@ -126,7 +126,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="tooltip bs-tooltip-right" role="tooltip">
 	<div class="arrow"></div>
 	<div class="tooltip-inner">

--- a/src/pages/docs/components/progress_bars.md
+++ b/src/pages/docs/components/progress_bars.md
@@ -78,6 +78,34 @@ weight: 100
 	</div>
 </div>
 ```
+```soy
+{call ClayProgressBar.render}
+	{param minValue: 0 /}
+	{param maxValue: 100 /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param value: 60 /}
+{/call}
+
+{call ClayProgressBar.render}
+	{param minValue: 0 /}
+	{param maxValue: 100 /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param status: 'warning' /}
+	{param value: 60 /}
+{/call}
+
+{call ClayProgressBar.render}
+	{param minValue: 0 /}
+	{param maxValue: 100 /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param value: 100 /}
+{/call}
+
+{call ClayProgressBar.render}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param status: 'complete' /}
+{/call}
+```
 
 </article>
 

--- a/src/pages/docs/components/progress_bars.md
+++ b/src/pages/docs/components/progress_bars.md
@@ -44,7 +44,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="progress-group">
 	<div class="progress">
 		<div aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" class="progress-bar" role="progressbar" style="width: 60%;"></div>
@@ -128,7 +128,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="progress-group progress-group-stacked">
 	<div class="progress-group-addon">60% Completed</div>
 	<div class="progress">
@@ -177,7 +177,7 @@ weight: 100
 	<div aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" class="progress-bar" role="progressbar" style="width: 100%;">100%</div>
 </div>
 
-```xml
+```text/html
 <div class="progress">
 	<div aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" class="progress-bar" role="progressbar" style="width: 25%;">25%</div>
 </div>
@@ -260,7 +260,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="progress-group">
 	<div class="progress">
 		<div aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" class="progress-bar" role="progressbar" style="width: 60%;"></div>
@@ -361,7 +361,7 @@ weight: 100
 	<div class="progress-bar progress-bar-animated progress-bar-striped" style="width: 10%">10%</div>
 </div>
 
-```xml
+```text/html
 <div class="progress">
 	<div class="bg-success progress-bar progress-bar-striped" style="width: 25%">25%</div>
 	<div class="bg-success progress-bar" style="width: 25%">25%</div>
@@ -414,7 +414,7 @@ weight: 100
 	<div class="progress-group-addon">60%</div>
 </div>
 
-```xml
+```text/html
 <div class="progress">
 	<div aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" class="progress-bar" role="progressbar" style="width: 25%;">25%</div>
 </div>
@@ -440,7 +440,7 @@ weight: 100
 	<div class="progress-group-addon">60%</div>
 </div>
 
-```xml
+```text/html
 <div class="progress progress-lg">
 	<div aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" class="progress-bar" role="progressbar" style="width: 45%;">45%</div>
 </div>
@@ -476,7 +476,7 @@ weight: 100
 	<div aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" class="bg-danger progress-bar" role="progressbar" style="width: 80%;">80% (Danger)</div>
 </div>
 
-```xml
+```text/html
 <div class="progress">
 	<div aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" class="bg-success progress-bar" role="progressbar" style="width: 60%;">60% (Success)</div>
 </div>

--- a/src/pages/docs/components/sidebar.md
+++ b/src/pages/docs/components/sidebar.md
@@ -29,7 +29,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="sidebar">
 	<div class="sidebar-header">
 		Sidebar Header
@@ -260,7 +260,7 @@ weight: 100
 	</div>
 </div>
 
-```xml
+```text/html
 <div class="sidebar sidebar-light">
 	<div class="sidebar-header">
 		<div class="sidebar-section-flex">

--- a/src/pages/docs/components/tables.md
+++ b/src/pages/docs/components/tables.md
@@ -220,7 +220,7 @@ weight: 100
 	</tbody>
 </table>
 
-```xml
+```text/html
 <table class="show-dropdown-action-on-active table table-autofit table-list table-responsive-lg">
 	<thead>
 		<tr>
@@ -529,7 +529,7 @@ weight: 100
 	</tbody>
 </table>
 
-```xml
+```text/html
 <table class="show-dropdown-action-on-active table table-autofit table-list table-responsive-sm table-striped">
 	<thead>
 		<tr>
@@ -908,7 +908,7 @@ weight: 100
 	</tbody>
 </table>
 
-```xml
+```text/html
 <table class="show-dropdown-action-on-active table table-autofit table-hover table-list table-responsive-sm">
 	<thead>
 		<tr>
@@ -1203,7 +1203,7 @@ weight: 100
 	</tbody>
 </table>
 
-```xml
+```text/html
 <table class="show-dropdown-action-on-active table table-autofit table-bordered table-list table-responsive-sm">
 	<thead>
 		<tr>
@@ -1700,7 +1700,7 @@ weight: 100
 	</tbody>
 </table>
 
-```xml
+```text/html
 ```
 
 </article>
@@ -1777,7 +1777,7 @@ weight: 100
 	</tbody>
 </table>
 
-```xml
+```text/html
 ```
 
 </article>
@@ -1854,7 +1854,7 @@ weight: 100
 	</tbody>
 </table>
 
-```xml
+```text/html
 ```
 
 </article>
@@ -1933,7 +1933,7 @@ weight: 100
 	</table>
 </div>
 
-```xml
+```text/html
 ```
 
 </article>

--- a/src/pages/docs/components/timelines.md
+++ b/src/pages/docs/components/timelines.md
@@ -73,7 +73,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="timeline">
 	<li class="timeline-item">
 		<div aria-multiselectable="true" class="panel-group" id="accordion000" role="tablist">
@@ -180,7 +180,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="timeline">
 	<li class="timeline-item">
 		<div class="panel panel-secondary">
@@ -264,7 +264,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="timeline timeline-right">
 	<li class="timeline-item">
 		<div class="panel panel-secondary">
@@ -362,7 +362,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="timeline timeline-center">
 	<li class="timeline-item">
 		<div aria-multiselectable="true" class="panel-group" id="accordionTimelineCenter0" role="tablist">
@@ -463,7 +463,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="timeline timeline-center timeline-even">
 	<li class="timeline-item">
 		<div class="panel panel-secondary">
@@ -557,7 +557,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="timeline timeline-center timeline-odd">
 	<li class="timeline-item">
 		<div class="panel panel-secondary">
@@ -651,7 +651,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="timeline timeline-center timeline-even timeline-right-xs-only">
 	<li class="timeline-item">
 		<div class="panel panel-default">
@@ -762,7 +762,7 @@ weight: 100
 	</li>
 </ul>
 
-```xml
+```text/html
 <ul class="timeline timeline-center timeline-spacing-xl">
 	<li class="timeline-item">
 		<div aria-multiselectable="true" class="panel-group" id="accordionTimelineSpacing0" role="tablist">

--- a/src/pages/docs/components/toggle_switch.md
+++ b/src/pages/docs/components/toggle_switch.md
@@ -20,7 +20,7 @@ weight: 100
 	</label>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label class="toggle-switch">
 		<input class="toggle-switch-check" type="checkbox">
@@ -58,7 +58,7 @@ weight: 100
 	</label>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label class="toggle-switch">
 		<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option1">
@@ -113,7 +113,7 @@ weight: 100
 	</label>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label class="toggle-switch">
 		<input class="toggle-switch-check" type="checkbox">
@@ -208,7 +208,7 @@ weight: 100
 	</label>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label class="toggle-switch">
 		<input class="toggle-switch-check" type="checkbox">
@@ -348,7 +348,7 @@ weight: 100
 	</label>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label class="toggle-switch">
 		<input class="toggle-switch-check" type="checkbox">
@@ -444,7 +444,7 @@ weight: 100
 	</label>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label class="toggle-switch">
 		<input class="toggle-switch-check" type="checkbox">
@@ -494,7 +494,7 @@ weight: 100
 	</label>
 </div>
 
-```xml
+```text/html
 <div class="form-group">
 	<label class="toggle-switch">
 		<input class="toggle-switch-check" disabled type="checkbox">


### PR DESCRIPTION
Hey guys,

> _This pr is in progress_

I'm working on adding examples of the clay components to soy based on what we currently have according to the [docs](https://issues.liferay.com/secure/RapidBoard.jspa?rapidView=2883) provided by the lexicon team.

I'm sending the pr to track progress and we'll be able to discuss how we are going to deal with the differences of Clay css and the components of clay in metal.

## Progress

- [x] Clay Alert 38100de
- [X] Clay Badge f4b19e2
- [x] Clay Button accf231
- [x] Clay Checkbox ac2a28c
- [x] Clay Icon 59e5858
- [X] Clay Label d3706bf
- [x] Clay Progress Bar 3278ae3
- [x] Clay Radio 81fb5b9
- [x] Clay Select 9bd49f4
- [X] Clay Sticker ce1de19

> _Current components in the [clay components](https://github.com/metal/metal-clay-components/tree/master/packages) repository._
> ##### Update 04/10/2017 12:06:00 BR 😁

#### They need to be updated
- Clay [Navbar]() [LEXI-166](https://issues.liferay.com/browse/LEXI-166)
- Clay Dropdown

## Discuss

### Confusion between markups
We have situations that the difference between the markup in html for soy, as an example of `Badge` f4b19e2, does not support anchors, sizes and links. Some come to support just a few colors like `Label` d3706bf.

#### Situation 1
Some examples of using `Badge` do not contain examples in soy, this can create confusion for anyone reading doc or wanting to know how to use an html template in soy. Since we're wanting devs to follow the rules of lexicon with clay components, I think we should pull out the other sample models.

#### Situation 2
It is worth mentioning that maybe some projects require special markups to use and it would be interesting to make available these examples of markup of clay css.

/cc @jbalsas, @Robert-Frampton, @carloslancha, @brunobasto