### PR TITLE
Update soy examples

### DIFF
--- a/src/pages/docs/components/buttons.md
+++ b/src/pages/docs/components/buttons.md
@@ -107,29 +107,29 @@ weight: 100
 ```
 ```soy
 {call ClayButton.render}
-	{param elementClasses: 'btn-monospaced' /}
-	{param label: 'Primary' /}
+	{param label: 'A' /}
+	{param monospaced: true /}
 	{param type: 'button' /}
 {/call}
 
 {call ClayButton.render}
-	{param elementClasses: 'btn-monospaced' /}
-	{param label: 'Secondary' /}
+	{param label: 'B' /}
 	{param style: 'secondary' /}
+	{param monospaced: true /}
 	{param type: 'button' /}
 {/call}
 
 {call ClayButton.render}
-	{param elementClasses: 'btn-monospaced' /}
-	{param label: 'Link' /}
+	{param label: 'C' /}
 	{param style: 'link' /}
+	{param monospaced: true /}
 	{param type: 'button' /}
 {/call}
 
 {call ClayButton.render}
-	{param elementClasses: 'btn-monospaced' /}
-	{param label: 'Unstyled' /}
+	{param label: 'D' /}
 	{param style: 'unstyled' /}
+	{param monospaced: true /}
 	{param type: 'button' /}
 {/call}
 ```
@@ -271,19 +271,19 @@ weight: 100
 ```soy
 {call ClayButton.render}
 	{param icon: [
-			'monospaced': true,
 			'spritemap': '/vendor/lexicon/icons.svg',
 			'symbol': 'blogs'
 	] /}
+	{param monospaced: true /}
 	{param size: 'sm' /}
 {/call}
 
 {call ClayButton.render}
 	{param icon: [
-			'monospaced': true,
 			'spritemap': '/vendor/lexicon/icons.svg',
 			'symbol': 'plus'
 	] /}
+	{param monospaced: true /}
 {/call}
 ```
 

--- a/src/pages/docs/components/form_elements.md
+++ b/src/pages/docs/components/form_elements.md
@@ -187,41 +187,6 @@ weight: 100
 	</label>
 </div>
 ```
-```soy
-{call ClayCheckbox.render}
-	{param hideLabel: true /}
-	{param label: 'Hidden Label Checkbox' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param label: 'Label' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param disabled: true /}
-	{param label: 'Disabled Check Box' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param disabled: true /}
-	{param label: 'Label' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param inline: true /}
-	{param label: 'Inline 1' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param inline: true /}
-	{param label: 'Inline 2' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param inline: true /}
-	{param label: 'Inline 3' /}
-{/call}
-```
 
 </article>
 
@@ -303,42 +268,6 @@ weight: 100
 		<input class="form-check-input" id="inlineRadio3" name="inlineRadioOptions1" type="radio" value="option3"> 3
 	</label>
 </div>
-```
-```soy
-{call ClayRadio.render}
-	{param hideLabel: true /}
-	{param label: 'Hidden Label Radio' /}
-{/call}
-
-{call ClayRadio.render}
-	{param label: 'Label' /}
-{/call}
-
-{call ClayRadio.render}
-	{param disabled: true /}
-	{param label: 'Disabled Radio Button' /}
-{/call}
-
-{call ClayRadio.render}
-	{param inline: true /}
-	{param label: '1' /}
-	{param name: 'inline-radio' /}
-	{param value: 'option1' /}
-{/call}
-
-{call ClayRadio.render}
-	{param inline: true /}
-	{param label: '2' /}
-	{param name: 'inline-radio' /}
-	{param value: 'option2' /}
-{/call}
-
-{call ClayRadio.render}
-	{param inline: true /}
-	{param label: '3' /}
-	{param name: 'inline-radio' /}
-	{param value: 'option3' /}
-{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/icons-lexicon.md
+++ b/src/pages/docs/components/icons-lexicon.md
@@ -27,7 +27,6 @@ weight: 100
 {/call}
 
 {call ClayIcon.render}
-	{param monospaced: true /}
 	{param spritemap: 'path/to/icons.svg' /}
 	{param symbol: 'add-column' /}
 {/call}


### PR DESCRIPTION
I'm updating the examples in the components **Buttons**, **Icons** and removing the **Checkbox** and **Radio** examples in **Form Elements**, Only support for **Form Elements custom**.

Resolved in https://github.com/metal/metal-clay-components/pull/123