### PR TITLE
Add examples of components with webcomponents

### DIFF
--- a/src/pages/docs/components/alerts.md
+++ b/src/pages/docs/components/alerts.md
@@ -140,43 +140,6 @@ weight: 100
 	<strong class="lead">Danger:</strong> <a href="#1" class="alert-link">Something</a> is not right.
 </div>
 
-```text/html
-<div class="alert alert-success" role="alert">
-	<span class="alert-indicator">
-		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check-circle-full">
-			<use xlink:href="/vendor/lexicon/icons.svg#check-circle-full"></use>
-		</svg>
-	</span>
-	<strong class="lead">Success:</strong> You just read the <a href="#1" class="alert-link">alert message</a> successfully.
-</div>
-
-<div class="alert alert-info" role="alert">
-	<span class="alert-indicator">
-		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
-			<use xlink:href="/vendor/lexicon/icons.svg#info-circle"></use>
-		</svg>
-	</span>
-	<strong class="lead">Info:</strong> This <a href="#1" class="alert-link">alert</a> needs your attention.
-</div>
-
-<div class="alert alert-warning" role="alert">
-	<span class="alert-indicator">
-		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-warning-full">
-			<use xlink:href="/vendor/lexicon/icons.svg#warning-full"></use>
-		</svg>
-	</span>
-	<strong class="lead">Warning:</strong> This alert is a <a href="#1" class="alert-link">warning message</a>.
-</div>
-
-<div class="alert alert-danger" role="alert">
-	<span class="alert-indicator">
-		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-full">
-			<use xlink:href="/vendor/lexicon/icons.svg#exclamation-full"></use>
-		</svg>
-	</span>
-	<strong class="lead">Danger:</strong> <a href="#1" class="alert-link">Something</a> is not right.
-</div>
-```
 ```soy
 {call ClayAlert.render}
 	{param message kind="html"}
@@ -216,6 +179,43 @@ weight: 100
 	{param style: 'danger' /}
 	{param title: 'Danger' /}
 {/param}
+```
+```text/html
+<div class="alert alert-success" role="alert">
+	<span class="alert-indicator">
+		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check-circle-full">
+			<use xlink:href="/vendor/lexicon/icons.svg#check-circle-full"></use>
+		</svg>
+	</span>
+	<strong class="lead">Success:</strong> You just read the <a href="#1" class="alert-link">alert message</a> successfully.
+</div>
+
+<div class="alert alert-info" role="alert">
+	<span class="alert-indicator">
+		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
+			<use xlink:href="/vendor/lexicon/icons.svg#info-circle"></use>
+		</svg>
+	</span>
+	<strong class="lead">Info:</strong> This <a href="#1" class="alert-link">alert</a> needs your attention.
+</div>
+
+<div class="alert alert-warning" role="alert">
+	<span class="alert-indicator">
+		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-warning-full">
+			<use xlink:href="/vendor/lexicon/icons.svg#warning-full"></use>
+		</svg>
+	</span>
+	<strong class="lead">Warning:</strong> This alert is a <a href="#1" class="alert-link">warning message</a>.
+</div>
+
+<div class="alert alert-danger" role="alert">
+	<span class="alert-indicator">
+		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-full">
+			<use xlink:href="/vendor/lexicon/icons.svg#exclamation-full"></use>
+		</svg>
+	</span>
+	<strong class="lead">Danger:</strong> <a href="#1" class="alert-link">Something</a> is not right.
+</div>
 ```
 
 </article>
@@ -278,6 +278,54 @@ weight: 100
 	</button>
 </div>
 
+```soy
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		You just read the <a href="#">alert message</a> successfully.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'success' /}
+	{param title: 'Success' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		This <a href="#">alert</a> needs your attention.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Info' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		This alert is a <a href="#">warning message</a>.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'warning' /}
+	{param title: 'Warning' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		Something</a> is not right.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'danger' /}
+	{param title: 'Danger' /}
+{/param}
+```
 ```text/html
 <div class="alert alert-dismissible alert-success" role="alert">
 	<span class="alert-indicator">
@@ -334,54 +382,6 @@ weight: 100
 		</svg>
 	</button>
 </div>
-```
-```soy
-{call ClayAlert.render}
-	{param closeable: true /}
-
-	{param message kind="html"}
-		You just read the <a href="#">alert message</a> successfully.
-	{/param}
-
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param style: 'success' /}
-	{param title: 'Success' /}
-{/param}
-
-{call ClayAlert.render}
-	{param closeable: true /}
-
-	{param message kind="html"}
-		This <a href="#">alert</a> needs your attention.
-	{/param}
-
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param title: 'Info' /}
-{/param}
-
-{call ClayAlert.render}
-	{param closeable: true /}
-
-	{param message kind="html"}
-		This alert is a <a href="#">warning message</a>.
-	{/param}
-
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param style: 'warning' /}
-	{param title: 'Warning' /}
-{/param}
-
-{call ClayAlert.render}
-	{param closeable: true /}
-
-	{param message kind="html"}
-		Something</a> is not right.
-	{/param}
-
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param style: 'danger' /}
-	{param title: 'Danger' /}
-{/param}
 ```
 
 </article>
@@ -452,6 +452,58 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		You just read the <a href="#">alert message</a> successfully.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'success' /}
+	{param title: 'Success' /}
+	{param type: 'fluid' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		This <a href="#">alert</a> needs your attention.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Info' /}
+	{param type: 'fluid' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		This alert is a <a href="#">warning message</a>.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'warning' /}
+	{param title: 'Warning' /}
+	{param type: 'fluid' /}
+{/param}
+
+{call ClayAlert.render}
+	{param closeable: true /}
+
+	{param message kind="html"}
+		Something</a> is not right.
+	{/param}
+
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param style: 'danger' /}
+	{param title: 'Danger' /}
+	{param type: 'fluid' /}
+{/param}
+```
 ```text/html
 <div class="alert alert-dismissible alert-fluid alert-success" role="alert">
 	<div class="container">
@@ -516,58 +568,6 @@ weight: 100
 		</button>
 	</div>
 </div>
-```
-```soy
-{call ClayAlert.render}
-	{param closeable: true /}
-
-	{param message kind="html"}
-		You just read the <a href="#">alert message</a> successfully.
-	{/param}
-
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param style: 'success' /}
-	{param title: 'Success' /}
-	{param type: 'fluid' /}
-{/param}
-
-{call ClayAlert.render}
-	{param closeable: true /}
-
-	{param message kind="html"}
-		This <a href="#">alert</a> needs your attention.
-	{/param}
-
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param title: 'Info' /}
-	{param type: 'fluid' /}
-{/param}
-
-{call ClayAlert.render}
-	{param closeable: true /}
-
-	{param message kind="html"}
-		This alert is a <a href="#">warning message</a>.
-	{/param}
-
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param style: 'warning' /}
-	{param title: 'Warning' /}
-	{param type: 'fluid' /}
-{/param}
-
-{call ClayAlert.render}
-	{param closeable: true /}
-
-	{param message kind="html"}
-		Something</a> is not right.
-	{/param}
-
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param style: 'danger' /}
-	{param title: 'Danger' /}
-	{param type: 'fluid' /}
-{/param}
 ```
 
 </article>

--- a/src/pages/docs/components/alerts.md
+++ b/src/pages/docs/components/alerts.md
@@ -180,6 +180,31 @@ weight: 100
 	{param title: 'Danger' /}
 {/param}
 ```
+```webcomponents
+<clay-alert
+	style="success"
+	message='You just read the <a href="#">alert message</a> successfully.' spritemap="/vendor/lexicon/icons.svg"
+	title="Success">
+</clay-alert>
+
+<clay-alert
+	message="This <a href='#'>alert</a> needs your attention." spritemap="/vendor/lexicon/icons.svg"
+	title="Info">
+</clay-alert>
+
+<clay-alert
+	style="warning"
+	message='This alert is a <a href="#">warning message</a>.' spritemap="/vendor/lexicon/icons.svg"
+	title="Warning">
+</clay-alert>
+
+<clay-alert
+	style="danger"
+	message='Something</a> is not right.'
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Danger">
+</clay-alert>
+```
 ```text/html
 <div class="alert alert-success" role="alert">
 	<span class="alert-indicator">
@@ -325,6 +350,37 @@ weight: 100
 	{param style: 'danger' /}
 	{param title: 'Danger' /}
 {/param}
+```
+```webcomponents
+<clay-alert
+	closeable="true"
+	style="success"
+	message='You just read the alert message successfully.' spritemap="/vendor/lexicon/icons.svg"
+	title="Success">
+</clay-alert>
+
+<clay-alert
+	closeable="true"
+	message="This alert needs your attention."
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Info">
+</clay-alert>
+
+<clay-alert
+	closeable="true"
+	style="warning"
+	message='This alert is a warning message.'
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Warning">
+</clay-alert>
+
+<clay-alert
+	closeable="true"
+	style="danger"
+	message='Something is not right.'
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Danger">
+</clay-alert>
 ```
 ```text/html
 <div class="alert alert-dismissible alert-success" role="alert">
@@ -503,6 +559,39 @@ weight: 100
 	{param title: 'Danger' /}
 	{param type: 'fluid' /}
 {/param}
+```
+```webcomponents
+<clay-alert
+	closeable="true"
+	style="success"
+	message='You just read the <a href="#">alert message</a> successfully.' spritemap="/vendor/lexicon/icons.svg"
+	title="Success"
+	type="fluid"
+></clay-alert>
+
+<clay-alert
+	closeable="true"
+	message="This <a href='#'>alert</a> needs your attention." spritemap="/vendor/lexicon/icons.svg"
+	title="Info"
+	type="fluid">
+</clay-alert>
+
+<clay-alert
+	closeable="true"
+	style="warning"
+	message='This alert is a <a href="#">warning message</a>.' spritemap="/vendor/lexicon/icons.svg"
+	title="Warning"
+	type="fluid">
+</clay-alert>
+
+<clay-alert
+	closeable="true"
+	style="danger"
+	message='Something</a> is not right.'
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Danger"
+	type="fluid">
+</clay-alert>
 ```
 ```text/html
 <div class="alert alert-dismissible alert-fluid alert-success" role="alert">

--- a/src/pages/docs/components/badges_and_labels.md
+++ b/src/pages/docs/components/badges_and_labels.md
@@ -16,14 +16,6 @@ weight: 100
 <span class="badge badge-warning">21</span>{sp}
 <span class="badge badge-danger">130</span>
 
-```text/html
-<span class="badge badge-primary">8</span>
-<span class="badge badge-secondary">87</span>
-<span class="badge badge-success">999K</span>
-<span class="badge badge-info">91</span>
-<span class="badge badge-warning">21</span>
-<span class="badge badge-danger">130</span>
-```
 ```soy
 {call ClayBadge.render}
 	{param label: '8' /}
@@ -38,6 +30,14 @@ weight: 100
 	{param label: '999K' /}
 	{param style: 'success' /}
 {/call}
+```
+```text/html
+<span class="badge badge-primary">8</span>
+<span class="badge badge-secondary">87</span>
+<span class="badge badge-success">999K</span>
+<span class="badge badge-info">91</span>
+<span class="badge badge-warning">21</span>
+<span class="badge badge-danger">130</span>
 ```
 
 </article>
@@ -54,14 +54,6 @@ weight: 100
 <span class="label label-warning">Warning</span>{sp}
 <span class="label label-danger">Danger</span>
 
-```text/html
-<span class="label label-primary">Primary</span>
-<span class="label label-secondary">Secondary</span>
-<span class="label label-success">Success</span>
-<span class="label label-info">Info</span>
-<span class="label label-warning">Warning</span>
-<span class="label label-danger">Danger</span>
-```
 ```soy
 {call ClayLabel.render}
 	{param label: 'Label Text' /}
@@ -86,6 +78,14 @@ weight: 100
 	{param label: 'Approved' /}
 	{param style: 'success' /}
 {/call}
+```
+```text/html
+<span class="label label-primary">Primary</span>
+<span class="label label-secondary">Secondary</span>
+<span class="label label-success">Success</span>
+<span class="label label-info">Info</span>
+<span class="label label-warning">Warning</span>
+<span class="label label-danger">Danger</span>
 ```
 
 </article>
@@ -102,14 +102,6 @@ weight: 100
 <a class="label label-warning" href="#1">Warning</a>{sp}
 <a class="label label-danger" href="#1">Danger</a>
 
-```text/html
-<a class="label label-primary" href="#1">Primary</a>
-<a class="label label-secondary" href="#1">Secondary</a>
-<a class="label label-success" href="#1">Success</a>
-<a class="label label-info" href="#1">Info</a>
-<a class="label label-warning" href="#1">Warning</a>
-<a class="label label-danger" href="#1">Danger</a>
-```
 ```soy
 {call ClayLabel.render}
 	{param href: '#1' /}
@@ -139,6 +131,14 @@ weight: 100
 	{param label: 'Approved' /}
 	{param style: 'success' /}
 {/call}
+```
+```text/html
+<a class="label label-primary" href="#1">Primary</a>
+<a class="label label-secondary" href="#1">Secondary</a>
+<a class="label label-success" href="#1">Success</a>
+<a class="label label-info" href="#1">Info</a>
+<a class="label label-warning" href="#1">Warning</a>
+<a class="label label-danger" href="#1">Danger</a>
 ```
 
 </article>
@@ -165,6 +165,21 @@ weight: 100
 	</button>
 </span>
 
+```soy
+{call ClayLabel.render}
+	{param closeable: true /}
+	{param label: 'Normal Label' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+{/call}
+
+{call ClayLabel.render}
+	{param closeable: true /}
+	{param label: 'Large Label' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param size: 'lg' /}
+	{param style: 'info' /}
+{/call}
+```
 ```text/html
 <span class="label label-dismissible label-secondary">
 	Normal Label
@@ -184,21 +199,6 @@ weight: 100
 	</button>
 </span>
 ```
-```soy
-{call ClayLabel.render}
-	{param closeable: true /}
-	{param label: 'Normal Label' /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-{/call}
-
-{call ClayLabel.render}
-	{param closeable: true /}
-	{param label: 'Large Label' /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param size: 'lg' /}
-	{param style: 'info' /}
-{/call}
-```
 
 </article>
 
@@ -212,10 +212,6 @@ weight: 100
 <span class="label label-secondary">Normal Label</span>{sp}
 <span class="label label-lg label-success">Large Label</span>{sp}
 
-```text/html
-<span class="label label-secondary">Normal Label</span>
-<span class="label label-lg label-success">Large Label</span>
-```
 ```soy
 {call ClayLabel.render}
 	{param closeable: true /}
@@ -227,6 +223,10 @@ weight: 100
 	{param size: 'lg' /}
 	{param style: 'info' /}
 {/call}
+```
+```text/html
+<span class="label label-secondary">Normal Label</span>
+<span class="label label-lg label-success">Large Label</span>
 ```
 
 </article>
@@ -245,14 +245,6 @@ weight: 100
 <span class="sticker sticker-warning">133</span>{sp}
 <span class="sticker sticker-danger">133</span>
 
-```text/html
-<span class="sticker sticker-primary">133</span>
-<span class="sticker sticker-secondary">133</span>
-<span class="sticker sticker-success">133</span>
-<span class="sticker sticker-info">133</span>
-<span class="sticker sticker-warning">133</span>
-<span class="sticker sticker-danger">133</span>
-```
 ```soy
 {call ClaySticker.render}
 	{param label: '133' /}
@@ -283,6 +275,14 @@ weight: 100
 	{param label: '133' /}
 	{param style: 'danger' /}
 {/call}
+```
+```text/html
+<span class="sticker sticker-primary">133</span>
+<span class="sticker sticker-secondary">133</span>
+<span class="sticker sticker-success">133</span>
+<span class="sticker sticker-info">133</span>
+<span class="sticker sticker-warning">133</span>
+<span class="sticker sticker-danger">133</span>
 ```
 
 </article>
@@ -329,24 +329,6 @@ weight: 100
 	</div>
 </div>
 
-```text/html
-<div class="aspect-ratio">
-	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
-	<span class="sticker sticker-danger sticker-top-left">PDF</span>
-</div>
-<div class="aspect-ratio">
-	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
-	<span class="sticker sticker-bottom-left sticker-danger">PDF</span>
-</div>
-<div class="aspect-ratio">
-	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
-	<span class="sticker sticker-danger sticker-top-right">PDF</span>
-</div>
-<div class="aspect-ratio">
-	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
-	<span class="sticker sticker-bottom-right sticker-danger">PDF</span>
-</div>
-```
 ```soy
 {call ClaySticker.render}
 	{param label: 'PDF' /}
@@ -372,6 +354,24 @@ weight: 100
 	{param style: 'danger' /}
 {/call}
 ```
+```text/html
+<div class="aspect-ratio">
+	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
+	<span class="sticker sticker-danger sticker-top-left">PDF</span>
+</div>
+<div class="aspect-ratio">
+	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
+	<span class="sticker sticker-bottom-left sticker-danger">PDF</span>
+</div>
+<div class="aspect-ratio">
+	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
+	<span class="sticker sticker-danger sticker-top-right">PDF</span>
+</div>
+<div class="aspect-ratio">
+	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
+	<span class="sticker sticker-bottom-right sticker-danger">PDF</span>
+</div>
+```
 
 </article>
 
@@ -387,36 +387,36 @@ weight: 100
 <span class="sticker sticker-lg sticker-success">133</span>{sp}
 <span class="sticker sticker-danger sticker-xl">133</span>
 
+```soy
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param size: 'sm' /}
+	{param style: 'primary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param style: 'secondary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param size: 'lg' /}
+	{param style: 'success' /}
+{/call}
+
+{call ClaySticker.render}
+	{param label: '133' /}
+	{param size: 'xl' /}
+	{param style: 'danger' /}
+{/call}
+```
 ```text/html
 <span class="sticker sticker-primary sticker-sm">133</span>
 <span class="sticker sticker-secondary">133</span>
 <span class="sticker sticker-lg sticker-success">133</span>
 <span class="sticker sticker-danger sticker-xl">133</span>
 ```
-```soy
-{call ClaySticker.render}
-	{param label: '133' /}
-	{param size: 'sm' /}
-	{param style: 'primary' /}
-{/call}
-
-{call ClaySticker.render}
-	{param label: '133' /}
-	{param style: 'secondary' /}
-{/call}
-
-{call ClaySticker.render}
-	{param label: '133' /}
-	{param size: 'lg' /}
-	{param style: 'success' /}
-{/call}
-
-{call ClaySticker.render}
-	{param label: '133' /}
-	{param size: 'xl' /}
-	{param style: 'danger' /}
-{/call}
-```
 
 <span class="sticker sticker-primary sticker-sm">
 	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
@@ -439,6 +439,42 @@ weight: 100
 	</svg>
 </span>
 
+```soy
+{call ClaySticker.render}
+	{param icon: [
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'format'
+	] /}
+	{param size: 'sm' /}
+	{param style: 'primary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param icon: [
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'format'
+	] /}
+	{param style: 'secondary' /}
+{/call}
+
+{call ClaySticker.render}
+	{param icon: [
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'format'
+	] /}
+	{param size: 'lg' /}
+	{param style: 'success' /}
+{/call}
+
+{call ClaySticker.render}
+	{param icon: [
+			'spritemap': '/vendor/lexicon/icons.svg',
+			'symbol': 'format'
+	] /}
+	{param size: 'xl' /}
+	{param style: 'danger' /}
+{/call}
+```
 ```text/html
 <span class="sticker sticker-primary sticker-sm">
 	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
@@ -460,42 +496,6 @@ weight: 100
 		<use xlink:href="/vendor/lexicon/icons.svg#format" />
 	</svg>
 </span>
-```
-```soy
-{call ClaySticker.render}
-	{param icon: [
-			'spritemap': '/vendor/lexicon/icons.svg',
-			'symbol': 'format'
-	] /}
-	{param size: 'sm' /}
-	{param style: 'primary' /}
-{/call}
-
-{call ClaySticker.render}
-	{param icon: [
-			'spritemap': '/vendor/lexicon/icons.svg',
-			'symbol': 'format'
-	] /}
-	{param style: 'secondary' /}
-{/call}
-
-{call ClaySticker.render}
-	{param icon: [
-			'spritemap': '/vendor/lexicon/icons.svg',
-			'symbol': 'format'
-	] /}
-	{param size: 'lg' /}
-	{param style: 'success' /}
-{/call}
-
-{call ClaySticker.render}
-	{param icon: [
-			'spritemap': '/vendor/lexicon/icons.svg',
-			'symbol': 'format'
-	] /}
-	{param size: 'xl' /}
-	{param style: 'danger' /}
-{/call}
 ```
 
 </article>
@@ -538,12 +538,6 @@ weight: 100
 <span class="rounded-circle sticker sticker-lg sticker-success">SP</span>{sp}
 <span class="rounded-circle sticker sticker-danger sticker-xl">WW</span>{sp}
 
-```text/html
-<span class="rounded-circle sticker sticker-primary sticker-sm">JB</span>
-<span class="rounded-circle sticker sticker-secondary">TT</span>
-<span class="rounded-circle sticker sticker-lg sticker-success">SP</span>
-<span class="rounded-circle sticker sticker-danger sticker-xl">WW</span>
-```
 ```soy
 {call ClaySticker.render}
 	{param label: 'JB' /}
@@ -567,6 +561,12 @@ weight: 100
 	{param size: 'xl' /}
 	{param style: 'danger' /}
 {/call}
+```
+```text/html
+<span class="rounded-circle sticker sticker-primary sticker-sm">JB</span>
+<span class="rounded-circle sticker sticker-secondary">TT</span>
+<span class="rounded-circle sticker sticker-lg sticker-success">SP</span>
+<span class="rounded-circle sticker sticker-danger sticker-xl">WW</span>
 ```
 
 </article>

--- a/src/pages/docs/components/badges_and_labels.md
+++ b/src/pages/docs/components/badges_and_labels.md
@@ -31,6 +31,19 @@ weight: 100
 	{param style: 'success' /}
 {/call}
 ```
+```webcomponents
+<clay-badge label="8"></clay-badge>
+
+<clay-badge label="87" style="secondary"></clay-badge>
+
+<clay-badge label="999K" style="success"></clay-badge>
+
+<clay-badge label="91" style="info"></clay-badge>
+
+<clay-badge label="21" style="warning"></clay-badge>
+
+<clay-badge label="130" style="danger"></clay-badge>
+```
 ```text/html
 <span class="badge badge-primary">8</span>
 <span class="badge badge-secondary">87</span>
@@ -78,6 +91,17 @@ weight: 100
 	{param label: 'Approved' /}
 	{param style: 'success' /}
 {/call}
+```
+```webcomponents
+<clay-label label="Label text"></clay-label>
+
+<clay-label label="Status" style="info"></clay-label>
+
+<clay-label label="Pending" style="warning"></clay-label>
+
+<clay-label label="Rejected" style="danger"></clay-label>
+
+<clay-label label="Approved" style="success"></clay-label>
 ```
 ```text/html
 <span class="label label-primary">Primary</span>
@@ -132,6 +156,17 @@ weight: 100
 	{param style: 'success' /}
 {/call}
 ```
+```webcomponents
+<clay-label href="#1" label="Label text"></clay-label>
+
+<clay-label href="#1" label="Status" style="info"></clay-label>
+
+<clay-label href="#1" label="Pending" style="warning"></clay-label>
+
+<clay-label href="#1" label="Rejected" style="danger"></clay-label>
+
+<clay-label href="#1" label="Approved" style="success"></clay-label>
+```
 ```text/html
 <a class="label label-primary" href="#1">Primary</a>
 <a class="label label-secondary" href="#1">Secondary</a>
@@ -180,6 +215,21 @@ weight: 100
 	{param style: 'info' /}
 {/call}
 ```
+```webcomponents
+<clay-label
+	closeable="true"
+	label="Normal Label"
+	spritemap="/vendor/lexicon/icons.svg">
+</clay-label>
+
+<clay-label
+	closeable="true"
+	label="Large Label"
+	spritemap="/vendor/lexicon/icons.svg"
+	size="lg"
+	style="info">
+</clay-label>
+```
 ```text/html
 <span class="label label-dismissible label-secondary">
 	Normal Label
@@ -223,6 +273,19 @@ weight: 100
 	{param size: 'lg' /}
 	{param style: 'info' /}
 {/call}
+```
+```webcomponents
+<clay-label
+	label="Normal Label"
+	spritemap="/vendor/lexicon/icons.svg">
+</clay-label>
+
+<clay-label
+	label="Large Label"
+	spritemap="/vendor/lexicon/icons.svg"
+	size="lg"
+	style="info">
+</clay-label>
 ```
 ```text/html
 <span class="label label-secondary">Normal Label</span>
@@ -275,6 +338,19 @@ weight: 100
 	{param label: '133' /}
 	{param style: 'danger' /}
 {/call}
+```
+```webcomponents
+<clay-sticker label="133"></clay-sticker>
+
+<clay-sticker label="133" style="secondary"></clay-sticker>
+
+<clay-sticker label="133" style="success"></clay-sticker>
+
+<clay-sticker label="133" style="info"></clay-sticker>
+
+<clay-sticker label="133" style="warning"></clay-sticker>
+
+<clay-sticker label="133" style="danger"></clay-sticker>
 ```
 ```text/html
 <span class="sticker sticker-primary">133</span>
@@ -354,6 +430,31 @@ weight: 100
 	{param style: 'danger' /}
 {/call}
 ```
+```webcomponents
+<clay-sticker
+	label="133"
+	position="top-left"
+	style="danger">
+</clay-sticker>
+
+<clay-sticker
+	label="133"
+	position="bottom-left"
+	style="danger">
+</clay-sticker>
+
+<clay-sticker
+	label="133"
+	position="top-right"
+	style="danger">
+</clay-sticker>
+
+<clay-sticker
+	label="133"
+	position="bottom-right"
+	style="danger">
+</clay-sticker>
+```
 ```text/html
 <div class="aspect-ratio">
 	<img alt="thumbnail" class="aspect-ratio-item-fluid" src="/images/thumbnail_hot_air_ballon.jpg">
@@ -410,6 +511,27 @@ weight: 100
 	{param size: 'xl' /}
 	{param style: 'danger' /}
 {/call}
+```
+```webcomponents
+<clay-sticker
+	label="133"
+	size="sm"
+	style="primary">
+</clay-sticker>
+
+<clay-sticker label="133" style="secondary"></clay-sticker>
+
+<clay-sticker
+	label="133"
+	size="lg"
+	style="success">
+</clay-sticker>
+
+<clay-sticker
+	label="133"
+	size="xl"
+	style="danger">
+</clay-sticker>
 ```
 ```text/html
 <span class="sticker sticker-primary sticker-sm">133</span>
@@ -474,6 +596,30 @@ weight: 100
 	{param size: 'xl' /}
 	{param style: 'danger' /}
 {/call}
+```
+```webcomponents
+<clay-sticker
+	icon="['spritemap': '/vendor/lexicon/icons.svg', 'symbol': 'format']"
+	size="sm"
+	style="primary">
+</clay-sticker>
+
+<clay-sticker
+	icon="['spritemap': '/vendor/lexicon/icons.svg', 'symbol': 'format']"
+	style="secondary">
+</clay-sticker>
+
+<clay-sticker
+	icon="['spritemap': '/vendor/lexicon/icons.svg', 'symbol': 'format']"
+	size="lg"
+	style="success">
+</clay-sticker>
+
+<clay-sticker
+	icon="['spritemap': '/vendor/lexicon/icons.svg', 'symbol': 'format']"
+	size="xl"
+	style="danger">
+</clay-sticker>
 ```
 ```text/html
 <span class="sticker sticker-primary sticker-sm">
@@ -541,26 +687,58 @@ weight: 100
 ```soy
 {call ClaySticker.render}
 	{param label: 'JB' /}
+	{param shape: 'circle' /}
 	{param size: 'sm' /}
 	{param style: 'primary' /}
 {/call}
 
 {call ClaySticker.render}
 	{param label: 'TT' /}
+	{param shape: 'circle' /}
 	{param style: 'secondary' /}
 {/call}
 
 {call ClaySticker.render}
 	{param label: 'SP' /}
+	{param shape: 'circle' /}
 	{param size: 'lg' /}
 	{param style: 'success' /}
 {/call}
 
 {call ClaySticker.render}
 	{param label: 'WW' /}
+	{param shape: 'circle' /}
 	{param size: 'xl' /}
 	{param style: 'danger' /}
 {/call}
+```
+```webcomponents
+<clay-sticker
+	label="JB"
+	shape="circle"
+	size="sm"
+	style="primary">
+</clay-sticker>
+
+<clay-sticker
+	label="TT"
+	shape="circle"
+	style="secondary">
+</clay-sticker>
+
+<clay-sticker
+	label="SP"
+	shape="circle"
+	size="lg"
+	style="success">
+</clay-sticker>
+
+<clay-sticker
+	label="WW"
+	shape="circle"
+	size="xl"
+	style="danger">
+</clay-sticker>
 ```
 ```text/html
 <span class="rounded-circle sticker sticker-primary sticker-sm">JB</span>

--- a/src/pages/docs/components/buttons.md
+++ b/src/pages/docs/components/buttons.md
@@ -38,6 +38,15 @@ weight: 100
 	{param type: 'button' /}
 {/call}
 ```
+```webcomponents
+<clay-button label="Primary" type="button"></clay-button>
+
+<clay-button label="Secondary" style="secondary" type="button"></clay-button>
+
+<clay-button label="Link" style="borderless" type="button"></clay-button>
+
+<clay-button label="Unstyled" style="link" type="button"></clay-button>
+```
 ```text/html
 <button class="btn btn-primary" type="button">Primary</button>
 <button class="btn btn-secondary" type="button">Secondary</button>
@@ -79,6 +88,34 @@ weight: 100
 	{param style: 'unstyled' /}
 	{param type: 'button' /}
 {/call}
+```
+```webcomponents
+<clay-button
+	disabled="true"
+	label="Primary"
+	type="button">
+</clay-button>
+
+<clay-button
+	disabled="true"
+	label="Secondary"
+	style="secondary"
+	type="button">
+</clay-button>
+
+<clay-button
+	disabled="true"
+	label="Link"
+	style="borderless"
+	type="button">
+</clay-button>
+
+<clay-button
+	disabled="true"
+	label="Unstyled"
+	style="link"
+	type="button">
+</clay-button>
 ```
 ```text/html
 <button class="btn btn-primary" disabled type="button">Primary</button>
@@ -126,6 +163,34 @@ weight: 100
 	{param monospaced: true /}
 	{param type: 'button' /}
 {/call}
+```
+```webcomponents
+<clay-button
+	label="A"
+	monospaced="true"
+	type="button">
+</clay-button>
+
+<clay-button
+	label="B"
+	style="secondary"
+	monospaced="true"
+	type="button">
+</clay-button>
+
+<clay-button
+	label="C"
+	style="borderless"
+	monospaced="true"
+	type="button">
+</clay-button>
+
+<clay-button
+	label="D"
+	style="link"
+	monospaced="true"
+	type="button">
+</clay-button>
 ```
 ```text/html
 <button class="btn btn-monospaced btn-primary" type="button">A</button>
@@ -189,6 +254,14 @@ weight: 100
 	{param triggerStyle: 'primary' /}
 {/call}
 ```
+```webcomponents
+<clay-dropdown
+	items='[{"label": "Action", "url": "#1"},{"separator": true, "type": : "group"},{"label": "Scope", "url": "#1"}]'
+	spritemap="/vendor/lexicon/icons.svg"
+	triggerLabel="Primary"
+	triggerStyle="primary">
+</clay-dropdown>
+```
 ```text/html
 <div class="btn-group">
 	<button aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" type="button">
@@ -238,6 +311,11 @@ weight: 100
 	{param label: 'Default' /}
 {/call}
 ```
+```webcomponents
+<clay-button label="Small" size="sm"></clay-button>
+
+<clay-button label="Default"></clay-button>
+```
 ```text/html
 <button class="btn btn-secondary btn-sm" type="button">Small</button>
 
@@ -273,6 +351,16 @@ weight: 100
 	{param monospaced: true /}
 {/call}
 ```
+```webcomponents
+<clay-button
+	icon='{"spritemap": "/vendor/lexicon/icons.svg", "symbol": "blogs"}' monospaced="true"
+	size="sm">
+</clay-button>
+
+<clay-button
+	icon='{"spritemap": "/vendor/lexicon/icons.svg", "symbol": "plus"}' monospaced="true">
+</clay-button>
+```
 ```text/html
 <button class="btn btn-monospaced btn-secondary btn-sm" type="button">
 	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-blogs">
@@ -301,6 +389,11 @@ weight: 100
 	{param block: true /}
 	{param label: 'Normal Block Level Button' /}
 {/call}
+```
+```webcomponents
+<clay-button block="true" label="Small Block Level Button" size="sm"></clay-button>
+
+<clay-button block="true" label="Normal Block Level Button"></clay-button>
 ```
 ```text/html
 <button class="btn btn-block btn-secondary btn-sm" type="button">Small Block Level Button</button>

--- a/src/pages/docs/components/buttons.md
+++ b/src/pages/docs/components/buttons.md
@@ -14,12 +14,6 @@ weight: 100
 <button class="btn btn-link" type="button">Link</button>{sp}
 <button class="btn btn-unstyled" type="button">Unstyled</button>{sp}
 
-```text/html
-<button class="btn btn-primary" type="button">Primary</button>
-<button class="btn btn-secondary" type="button">Secondary</button>
-<button class="btn btn-link" type="button">Link</button>
-<button class="btn btn-unstyled" type="button">Unstyled</button>
-```
 ```soy
 {call ClayButton.render}
 	{param label: 'Primary' /}
@@ -43,6 +37,12 @@ weight: 100
 	{param style: 'unstyled' /}
 	{param type: 'button' /}
 {/call}
+```
+```text/html
+<button class="btn btn-primary" type="button">Primary</button>
+<button class="btn btn-secondary" type="button">Secondary</button>
+<button class="btn btn-link" type="button">Link</button>
+<button class="btn btn-unstyled" type="button">Unstyled</button>
 ```
 
 ### Disabled
@@ -52,12 +52,6 @@ weight: 100
 <button class="btn btn-link" disabled type="button">Link</button>{sp}
 <button class="btn btn-unstyled" disabled type="button">Unstyled</button>{sp}
 
-```text/html
-<button class="btn btn-primary" disabled type="button">Primary</button>
-<button class="btn btn-secondary" disabled type="button">Secondary</button>
-<button class="btn btn-link" disabled type="button">Link</button>
-<button class="btn btn-unstyled" disabled type="button">Unstyled</button>
-```
 ```soy
 {call ClayButton.render}
 	{param disabled: true /}
@@ -85,6 +79,12 @@ weight: 100
 	{param style: 'unstyled' /}
 	{param type: 'button' /}
 {/call}
+```
+```text/html
+<button class="btn btn-primary" disabled type="button">Primary</button>
+<button class="btn btn-secondary" disabled type="button">Secondary</button>
+<button class="btn btn-link" disabled type="button">Link</button>
+<button class="btn btn-unstyled" disabled type="button">Unstyled</button>
 ```
 
 </article>
@@ -99,12 +99,6 @@ weight: 100
 <button class="btn btn-monospaced btn-link" type="button">C</button>{sp}
 <button class="btn btn-monospaced btn-unstyled" type="button">D</button>
 
-```text/html
-<button class="btn btn-monospaced btn-primary" type="button">A</button>
-<button class="btn btn-monospaced btn-secondary" type="button">B</button>
-<button class="btn btn-monospaced btn-link" type="button">C</button>
-<button class="btn btn-monospaced btn-unstyled" type="button">D</button>
-```
 ```soy
 {call ClayButton.render}
 	{param label: 'A' /}
@@ -132,6 +126,12 @@ weight: 100
 	{param monospaced: true /}
 	{param type: 'button' /}
 {/call}
+```
+```text/html
+<button class="btn btn-monospaced btn-primary" type="button">A</button>
+<button class="btn btn-monospaced btn-secondary" type="button">B</button>
+<button class="btn btn-monospaced btn-link" type="button">C</button>
+<button class="btn btn-monospaced btn-unstyled" type="button">D</button>
 ```
 
 </article>
@@ -168,6 +168,27 @@ weight: 100
 	</div>
 </div>{sp}
 
+```soy
+{call ClayDropdown.render}
+	{param items: [
+		[
+			'label': 'Action',
+			'url': '#1'
+		],
+		[
+			'separator': true,
+			'type': 'group'
+		],
+		[
+			'label': 'Scope',
+			'url': '#1'
+		]
+	] /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param triggerLabel: 'Primary' /}
+	{param triggerStyle: 'primary' /}
+{/call}
+```
 ```text/html
 <div class="btn-group">
 	<button aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" type="button">
@@ -196,27 +217,6 @@ weight: 100
 	</div>
 </div>
 ```
-```soy
-{call ClayDropdown.render}
-	{param items: [
-		[
-			'label': 'Action',
-			'url': '#1'
-		],
-		[
-			'separator': true,
-			'type': 'group'
-		],
-		[
-			'label': 'Scope',
-			'url': '#1'
-		]
-	] /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param triggerLabel: 'Primary' /}
-	{param triggerStyle: 'primary' /}
-{/call}
-```
 
 </article>
 
@@ -228,11 +228,6 @@ weight: 100
 <button class="btn btn-secondary btn-sm" type="button">Small</button>{sp}
 <button class="btn btn-secondary" type="button">Default</button>
 
-```text/html
-<button class="btn btn-secondary btn-sm" type="button">Small</button>
-
-<button class="btn btn-secondary" type="button">Default</button>
-```
 ```soy
 {call ClayButton.render}
 	{param label: 'Small' /}
@@ -242,6 +237,11 @@ weight: 100
 {call ClayButton.render}
 	{param label: 'Default' /}
 {/call}
+```
+```text/html
+<button class="btn btn-secondary btn-sm" type="button">Small</button>
+
+<button class="btn btn-secondary" type="button">Default</button>
 ```
 
 <button class="btn btn-monospaced btn-secondary btn-sm" type="button">
@@ -255,19 +255,6 @@ weight: 100
 	</svg>
 </button>
 
-```text/html
-<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
-	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-blogs">
-		<use xlink:href="/vendor/lexicon/icons.svg#blogs"></use>
-	</svg>
-</button>
-
-<button class="btn btn-monospaced btn-secondary" type="button">
-	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
-		<use xlink:href="/vendor/lexicon/icons.svg#plus"></use>
-	</svg>
-</button>
-```
 ```soy
 {call ClayButton.render}
 	{param icon: [
@@ -286,15 +273,23 @@ weight: 100
 	{param monospaced: true /}
 {/call}
 ```
+```text/html
+<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-blogs">
+		<use xlink:href="/vendor/lexicon/icons.svg#blogs"></use>
+	</svg>
+</button>
+
+<button class="btn btn-monospaced btn-secondary" type="button">
+	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
+		<use xlink:href="/vendor/lexicon/icons.svg#plus"></use>
+	</svg>
+</button>
+```
 
 <button class="btn btn-block btn-secondary btn-sm" type="button">Small Block Level Button</button>{sp}
 <button class="btn btn-block btn-secondary" type="button">Normal Block Level Button</button>
 
-```text/html
-<button class="btn btn-block btn-secondary btn-sm" type="button">Small Block Level Button</button>
-
-<button class="btn btn-block btn-secondary" type="button">Normal Block Level Button</button>
-```
 ```soy
 {call ClayButton.render}
 	{param block: true /}
@@ -306,6 +301,11 @@ weight: 100
 	{param block: true /}
 	{param label: 'Normal Block Level Button' /}
 {/call}
+```
+```text/html
+<button class="btn btn-block btn-secondary btn-sm" type="button">Small Block Level Button</button>
+
+<button class="btn btn-block btn-secondary" type="button">Normal Block Level Button</button>
 ```
 
 </article>

--- a/src/pages/docs/components/form_custom.md
+++ b/src/pages/docs/components/form_custom.md
@@ -58,6 +58,38 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayCheckbox.render}
+	{param label: 'Unchecked' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param checked: true /}
+	{param label: 'Checked' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param indeterminate: true /}
+	{param label: 'Indeterminate' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param disabled: true /}
+	{param label: 'Unchecked disabled' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param checked: true /}
+	{param disabled: true /}
+	{param label: 'Checked disabled' /}
+{/call}
+
+{call ClayCheckbox.render}
+	{param disabled: true /}
+	{param indeterminate: true /}
+	{param label: 'Indeterminate disabled' /}
+{/call}
+```
 ```text/html
 <div class="custom-control custom-checkbox">
 	<label>
@@ -107,38 +139,6 @@ weight: 100
 	</label>
 </div>
 ```
-```soy
-{call ClayCheckbox.render}
-	{param label: 'Unchecked' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param checked: true /}
-	{param label: 'Checked' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param indeterminate: true /}
-	{param label: 'Indeterminate' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param disabled: true /}
-	{param label: 'Unchecked disabled' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param checked: true /}
-	{param disabled: true /}
-	{param label: 'Checked disabled' /}
-{/call}
-
-{call ClayCheckbox.render}
-	{param disabled: true /}
-	{param indeterminate: true /}
-	{param label: 'Indeterminate disabled' /}
-{/call}
-```
 
 </article>
 
@@ -164,6 +164,20 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayRadio.render}
+	{param checked: true /}
+	{param id: 'radio1' /}
+	{param label: 'Toggle this custom radio' /}
+	{param name: 'radio' /}
+{/call}
+
+{call ClayRadio.render}
+	{param id: 'radio2' /}
+	{param label: 'Or toggle this other custom radio' /}
+	{param name: 'radio' /}
+{/call}
+```
 ```text/html
 <div class="custom-control custom-radio">
 	<label>
@@ -180,20 +194,6 @@ weight: 100
 		<span class="custom-control-description">Or toggle this other custom radio</span>
 	</label>
 </div>
-```
-```soy
-{call ClayRadio.render}
-	{param checked: true /}
-	{param id: 'radio1' /}
-	{param label: 'Toggle this custom radio' /}
-	{param name: 'radio' /}
-{/call}
-
-{call ClayRadio.render}
-	{param id: 'radio2' /}
-	{param label: 'Or toggle this other custom radio' /}
-	{param name: 'radio' /}
-{/call}
 ```
 
 </article>
@@ -220,6 +220,20 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayRadio.render}
+	{param disabled: true /}
+	{param id: 'radioStacked3' /}
+	{param label: 'Toggle this custom radio' /}
+	{param name: 'radio-stacked' /}
+{/call}
+
+{call ClayRadio.render}
+	{param id: 'radioStacked4' /}
+	{param label: 'Or toggle this other custom radio' /}
+	{param name: 'radio-stacked' /}
+{/call}
+```
 ```text/html
 <div class="custom-control custom-control-inline custom-radio">
 	<label>
@@ -235,20 +249,6 @@ weight: 100
 		<span class="custom-control-description">Or toggle this other custom radio</span>
 	</label>
 </div>
-```
-```soy
-{call ClayRadio.render}
-	{param disabled: true /}
-	{param id: 'radioStacked3' /}
-	{param label: 'Toggle this custom radio' /}
-	{param name: 'radio-stacked' /}
-{/call}
-
-{call ClayRadio.render}
-	{param id: 'radioStacked4' /}
-	{param label: 'Or toggle this other custom radio' /}
-	{param name: 'radio-stacked' /}
-{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/form_custom.md
+++ b/src/pages/docs/components/form_custom.md
@@ -90,6 +90,36 @@ weight: 100
 	{param label: 'Indeterminate disabled' /}
 {/call}
 ```
+```webcomponents
+<clay-checkbox label="Unchecked"></clay-checkbox>
+
+<clay-checkbox
+	checked="true"
+	label="Checked">
+</clay-checkbox>
+
+<clay-checkbox
+	indeterminate="true"
+	label="Indeterminate">
+</clay-checkbox>
+
+<clay-checkbox
+	disable="true"
+	label="Unchecked disabled">
+</clay-checkbox>
+
+<clay-checkbox
+	hecked="true"
+	disabled="true"
+	label="Checked disabled">
+</clay-checkbox>
+
+<clay-checkbox
+	disabled="true"
+	indeterminate="true"
+	label="Indeterminate disabled">
+</clay-checkbox>
+```
 ```text/html
 <div class="custom-control custom-checkbox">
 	<label>
@@ -178,6 +208,20 @@ weight: 100
 	{param name: 'radio' /}
 {/call}
 ```
+```webcomponents
+<clay-radio
+	checked="true"
+	id="radio1"
+	label="Toggle this custom radio"
+	name="radio">
+</clay-radio>
+
+<clay-radio
+	id="radio2"
+	label="Or toggle this other custom radio"
+	name="radio">
+</clay-radio>
+```
 ```text/html
 <div class="custom-control custom-radio">
 	<label>
@@ -233,6 +277,20 @@ weight: 100
 	{param label: 'Or toggle this other custom radio' /}
 	{param name: 'radio-stacked' /}
 {/call}
+```
+```webcomponents
+<clay-radio
+	disabled="true"
+	id="radioStacked3"
+	label="Toggle this custom radio"
+	name="radio-stacked">
+</clay-radio>
+
+<clay-radio
+	id="radioStacked4"
+	label="Or toggle this other custom radio"
+	name="radio-stacked">
+</clay-radio>
 ```
 ```text/html
 <div class="custom-control custom-control-inline custom-radio">

--- a/src/pages/docs/components/form_elements.md
+++ b/src/pages/docs/components/form_elements.md
@@ -356,6 +356,20 @@ weight: 100
 	] /}
 {/call}
 ```
+```webcomponents
+<clay-select
+	id="regularSelectElement"
+	label="Regular Select Element"
+	options='[{"label":"Sample 1", "value": "1", "label":"Sample 2", "value": "2"}]'>
+</clay-select>
+
+<clay-select
+	id="multipleSelectOptionsSelectElement"
+	label="Select Element with Multiple Select Options"
+	multiple="true"
+	options='[{"label":"Sample 1", "value": "1", "label":"Sample 2", "value": "2"}]'>
+</clay-select>
+```
 ```text/html
 <div class="form-group">
 	<label for="regularSelectElement">Regular Select Element</label>

--- a/src/pages/docs/components/form_elements.md
+++ b/src/pages/docs/components/form_elements.md
@@ -308,31 +308,6 @@ weight: 100
 	</div>
 </div>
 
-```text/html
-<div class="form-group">
-	<label for="regularSelectElement">Regular Select Element</label>
-	<select class="form-control" id="regularSelectElement">
-		<option>Sample 1</option>
-		<option>Sample 2</option>
-		<option>Sample 3</option>
-		<option>Sample 4</option>
-	</select>
-</div>
-
-<div class="form-group">
-	<label for="multipleSelectOptionsSelectElement">Select Element with Multiple Select Options</label>
-	<select class="form-control" id="multipleSelectOptionsSelectElement" multiple>
-		<option>Sample 1</option>
-		<option>Sample 2</option>
-		<option>Sample 3</option>
-		<option>Sample 4</option>
-		<option>Sample 5</option>
-		<option>Sample 6</option>
-		<option>Sample 7</option>
-		<option>Sample 8</option>
-	</select>
-</div>
-```
 ```soy
 {call ClaySelect.render}
 	{param id: 'regularSelectElement' /}
@@ -380,6 +355,31 @@ weight: 100
 		],
 	] /}
 {/call}
+```
+```text/html
+<div class="form-group">
+	<label for="regularSelectElement">Regular Select Element</label>
+	<select class="form-control" id="regularSelectElement">
+		<option>Sample 1</option>
+		<option>Sample 2</option>
+		<option>Sample 3</option>
+		<option>Sample 4</option>
+	</select>
+</div>
+
+<div class="form-group">
+	<label for="multipleSelectOptionsSelectElement">Select Element with Multiple Select Options</label>
+	<select class="form-control" id="multipleSelectOptionsSelectElement" multiple>
+		<option>Sample 1</option>
+		<option>Sample 2</option>
+		<option>Sample 3</option>
+		<option>Sample 4</option>
+		<option>Sample 5</option>
+		<option>Sample 6</option>
+		<option>Sample 7</option>
+		<option>Sample 8</option>
+	</select>
+</div>
 ```
 
 </article>

--- a/src/pages/docs/components/icons-lexicon.md
+++ b/src/pages/docs/components/icons-lexicon.md
@@ -15,11 +15,6 @@ weight: 100
 
 > We use SVG elements that link to an SVG sprite, like so:
 
-```text/html
-<svg class="lexicon-icon">
-	<use xlink:href="path/to/icons.svg#add-column" />
-</svg>
-```
 ```soy
 {call ClayIcon.render}
 	{param spritemap: 'path/to/icons.svg' /}
@@ -30,6 +25,11 @@ weight: 100
 	{param spritemap: 'path/to/icons.svg' /}
 	{param symbol: 'add-column' /}
 {/call}
+```
+```text/html
+<svg class="lexicon-icon">
+	<use xlink:href="path/to/icons.svg#add-column" />
+</svg>
 ```
 
 > Note that the ID after the # symbol is the ID of the icon to use, so if you wanted to use plus icon, you would do change the `href` to `path/to/icons.svg#plus`.

--- a/src/pages/docs/components/icons-lexicon.md
+++ b/src/pages/docs/components/icons-lexicon.md
@@ -23,8 +23,13 @@ weight: 100
 
 {call ClayIcon.render}
 	{param spritemap: 'path/to/icons.svg' /}
-	{param symbol: 'add-column' /}
+	{param symbol: 'add-cell' /}
 {/call}
+```
+```webcomponents
+<clay-icon spritemap="path/to/icons.svg" symbol="add-column"></clay-icon>
+
+<clay-icon spritemap="path/to/icons.svg" symbol="add-cell"></clay-icon>
 ```
 ```text/html
 <svg class="lexicon-icon">

--- a/src/pages/docs/components/modals.md
+++ b/src/pages/docs/components/modals.md
@@ -34,6 +34,26 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayModal.render}
+	{param body kind="html"}
+		<h4>Modal Body</h4>
+	{/param}
+
+	{param footerButtons: [
+			[
+				'label': 'Primary'
+			],
+			[
+				'label': 'Close',
+				'type': 'close'
+			]
+	] /}
+	{param size: 'sm' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Modal Title' /}
+{/call}
+```
 ```text/html
 <button class="btn btn-info" data-target="#claySmallModal" data-toggle="modal" type="button">Small Modal</button>
 <div aria-labelledby="claySmallModalLabel" class="fade modal" id="claySmallModal" role="dialog" tabindex="-1">
@@ -57,26 +77,6 @@ weight: 100
 		</div>
 	</div>
 </div>
-```
-```soy
-{call ClayModal.render}
-	{param body kind="html"}
-		<h4>Modal Body</h4>
-	{/param}
-
-	{param footerButtons: [
-			[
-				'label': 'Primary'
-			],
-			[
-				'label': 'Close',
-				'type': 'close'
-			]
-	] /}
-	{param size: 'sm' /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param title: 'Modal Title' /}
-{/call}
 ```
 
 </article>
@@ -110,6 +110,25 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayModal.render}
+	{param body kind="html"}
+		<h4>Modal Body</h4>
+	{/param}
+
+	{param footerButtons: [
+			[
+				'label': 'Primary'
+			],
+			[
+				'label': 'Close',
+				'type': 'close'
+			]
+	] /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Modal Title' /}
+{/call}
+```
 ```text/html
 <button class="btn btn-info" data-target="#clayDefaultModal" data-toggle="modal" type="button">Default Modal</button>
 <div aria-labelledby="clayDefaultModalLabel" class="fade modal" id="clayDefaultModal" role="dialog" tabindex="-1">
@@ -133,25 +152,6 @@ weight: 100
 		</div>
 	</div>
 </div>
-```
-```soy
-{call ClayModal.render}
-	{param body kind="html"}
-		<h4>Modal Body</h4>
-	{/param}
-
-	{param footerButtons: [
-			[
-				'label': 'Primary'
-			],
-			[
-				'label': 'Close',
-				'type': 'close'
-			]
-	] /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param title: 'Modal Title' /}
-{/call}
 ```
 
 </article>
@@ -187,6 +187,26 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayModal.render}
+	{param body kind="html"}
+		<h4>Modal Body</h4>
+	{/param}
+
+	{param footerButtons: [
+			[
+				'label': 'Primary'
+			],
+			[
+				'label': 'Close',
+				'type': 'close'
+			]
+	] /}
+	{param size: 'lg' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Modal Title' /}
+{/call}
+```
 ```text/html
 <button class="btn btn-info" data-target="#clayLargeModal" data-toggle="modal" type="button">Large Modal</button>
 <div aria-labelledby="clayLargeModalLabel" class="fade modal" id="clayLargeModal" role="dialog" tabindex="-1">
@@ -210,26 +230,6 @@ weight: 100
 		</div>
 	</div>
 </div>
-```
-```soy
-{call ClayModal.render}
-	{param body kind="html"}
-		<h4>Modal Body</h4>
-	{/param}
-
-	{param footerButtons: [
-			[
-				'label': 'Primary'
-			],
-			[
-				'label': 'Close',
-				'type': 'close'
-			]
-	] /}
-	{param size: 'lg' /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param title: 'Modal Title' /}
-{/call}
 ```
 
 </article>
@@ -440,6 +440,106 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayModal.render}
+	{param body kind="html"}
+		<h4>Modal Body</h4>
+		<div>
+			<p>
+				<a href="#1">Crema coffee</a> a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
+			</p>
+			<p>
+				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
+			</p>
+			<p>
+				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
+			</p>
+			<p>
+				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
+			</p>
+			<p>
+				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
+			</p>
+			<p>
+				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
+			</p>
+		</div>
+		<div>
+			<p>
+				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
+			</p>
+			<p>
+				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
+			</p>
+			<p>
+				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
+			</p>
+			<p>
+				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
+			</p>
+			<p>
+				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
+			</p>
+			<p>
+				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
+			</p>
+		</div>
+		<div>
+			<p>
+				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
+			</p>
+			<p>
+				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
+			</p>
+			<p>
+				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
+			</p>
+			<p>
+				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
+			</p>
+			<p>
+				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
+			</p>
+			<p>
+				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
+			</p>
+		</div>
+		<div>
+			<p>
+				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
+			</p>
+			<p>
+				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
+			</p>
+			<p>
+				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
+			</p>
+			<p>
+				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
+			</p>
+			<p>
+				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
+			</p>
+			<p>
+				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
+			</p>
+		</div>
+	{/param}
+
+	{param footerButtons: [
+			[
+				'label': 'Add'
+			],
+			[
+				'label': 'Close',
+				'type': 'close'
+			]
+	] /}
+	{param size: 'full-screen' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Add Picture to Documents and Media Library in Liferay Seven' /}
+{/call}
+```
 ```text/html
 <button class="btn btn-info" data-target="#clayFullScreenModal" data-toggle="modal" type="button">Full Screen Modal</button>
 <div aria-labelledby="clayLargeModalLabel" class="fade modal" id="clayFullScreenModal" role="dialog" tabindex="-1">
@@ -543,106 +643,6 @@ weight: 100
 		</div>
 	</div>
 </div>
-```
-```soy
-{call ClayModal.render}
-	{param body kind="html"}
-		<h4>Modal Body</h4>
-		<div>
-			<p>
-				<a href="#1">Crema coffee</a> a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
-			</p>
-			<p>
-				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
-			</p>
-			<p>
-				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
-			</p>
-			<p>
-				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
-			</p>
-			<p>
-				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
-			</p>
-			<p>
-				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
-			</p>
-		</div>
-		<div>
-			<p>
-				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
-			</p>
-			<p>
-				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
-			</p>
-			<p>
-				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
-			</p>
-			<p>
-				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
-			</p>
-			<p>
-				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
-			</p>
-			<p>
-				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
-			</p>
-		</div>
-		<div>
-			<p>
-				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
-			</p>
-			<p>
-				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
-			</p>
-			<p>
-				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
-			</p>
-			<p>
-				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
-			</p>
-			<p>
-				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
-			</p>
-			<p>
-				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
-			</p>
-		</div>
-		<div>
-			<p>
-				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
-			</p>
-			<p>
-				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
-			</p>
-			<p>
-				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
-			</p>
-			<p>
-				Crema coffee a turkish decaffeinated espresso dripper cortado lungo con panna. Coffee, roast cup blue mountain beans single origin eu shop grounds caffeine a robusta. Sweet macchiato spoon, mug foam ut est ristretto.
-			</p>
-			<p>
-				Irish coffee, at as cultivar robusta fair trade. Variety, caramelization, sweet, steamed, breve sit, whipped spoon at in caffeine. So latte, half and half, instant café au lait whipped extra at percolator.
-			</p>
-			<p>
-				Skinny extraction, viennese arabica aromatic robust kopi-luwak. Carajillo chicory dark espresso qui iced sugar. To go, at café au lait chicory, qui, fair trade irish, beans seasonal extraction cappuccino kopi-luwak.
-			</p>
-		</div>
-	{/param}
-
-	{param footerButtons: [
-			[
-				'label': 'Add'
-			],
-			[
-				'label': 'Close',
-				'type': 'close'
-			]
-	] /}
-	{param size: 'full-screen' /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param title: 'Add Picture to Documents and Media Library in Liferay Seven' /}
-{/call}
 ```
 
 </article>
@@ -768,6 +768,23 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayModal.render}
+	{param footerButtons: [
+			[
+				'label': 'Add'
+			],
+			[
+				'label': 'Close',
+				'type': 'close'
+			]
+	] /}
+	{param size: 'full-screen' /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param title: 'Add Picture to Documents and Media Library in Liferay Seven' /}
+	{param url: 'https://claycss.com' /}
+{/call}
+```
 ```text/html
 <button class="btn btn-info" data-target="#clayFullScreenModalIframe" data-toggle="modal" type="button">Full Screen Modal Iframe</button>
 <div aria-labelledby="clayFullScreenModalIframeLabel" class="fade modal" id="clayFullScreenModalIframe" role="dialog" tabindex="-1">
@@ -791,23 +808,6 @@ weight: 100
 		</div>
 	</div>
 </div>
-```
-```soy
-{call ClayModal.render}
-	{param footerButtons: [
-			[
-				'label': 'Add'
-			],
-			[
-				'label': 'Close',
-				'type': 'close'
-			]
-	] /}
-	{param size: 'full-screen' /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param title: 'Add Picture to Documents and Media Library in Liferay Seven' /}
-	{param url: 'https://claycss.com' /}
-{/call}
 ```
 
 </article>
@@ -946,44 +946,6 @@ weight: 100
 	</div>
 </div>
 
-
-```text/html
-<button class="btn btn-danger" data-target="#clayModalDanger" data-toggle="modal" type="button">Modal Danger</button>
-<div aria-labelledby="clayModalDangerLabel" class="fade modal" id="clayModalDanger" role="dialog" tabindex="-1">
-	<div class="modal-danger modal-dialog modal-full-screen-sm-down">
-		<div class="modal-content">
-			<div class="modal-header">
-				<div class="modal-title" id="clayModalDangerLabel">
-					<span class="modal-title-indicator">
-						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-full">
-							<use xlink:href="/vendor/lexicon/icons.svg#exclamation-full" />
-						</svg>
-					</span>
-					Modal Title
-				</div>
-				<button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
-					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
-						<use xlink:href="/vendor/lexicon/icons.svg#times" />
-					</svg>
-				</button>
-			</div>
-			<div class="modal-body">
-				<h4>Modal Body</h4>
-			</div>
-			<div class="modal-footer">
-				<div class="modal-item-first">
-					<button class="btn btn-primary" type="button">Primary</button>
-				</div>
-				<div class="modal-item">Some other content</div>
-				<div class="modal-item-last">
-					<button class="btn btn-secondary" data-dismiss="modal" type="button">Close</button>
-					<button class="btn btn-primary" type="button">Primary</button>
-				</div>
-			</div>
-		</div>
-	</div>
-</div>
-```
 ```soy
 /**
  * Modal danger
@@ -1080,6 +1042,43 @@ weight: 100
 	{param status: 'warning' /}
 	{param title: 'Modal Title' /}
 {/call}
+```
+```text/html
+<button class="btn btn-danger" data-target="#clayModalDanger" data-toggle="modal" type="button">Modal Danger</button>
+<div aria-labelledby="clayModalDangerLabel" class="fade modal" id="clayModalDanger" role="dialog" tabindex="-1">
+	<div class="modal-danger modal-dialog modal-full-screen-sm-down">
+		<div class="modal-content">
+			<div class="modal-header">
+				<div class="modal-title" id="clayModalDangerLabel">
+					<span class="modal-title-indicator">
+						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-full">
+							<use xlink:href="/vendor/lexicon/icons.svg#exclamation-full" />
+						</svg>
+					</span>
+					Modal Title
+				</div>
+				<button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+						<use xlink:href="/vendor/lexicon/icons.svg#times" />
+					</svg>
+				</button>
+			</div>
+			<div class="modal-body">
+				<h4>Modal Body</h4>
+			</div>
+			<div class="modal-footer">
+				<div class="modal-item-first">
+					<button class="btn btn-primary" type="button">Primary</button>
+				</div>
+				<div class="modal-item">Some other content</div>
+				<div class="modal-item-last">
+					<button class="btn btn-secondary" data-dismiss="modal" type="button">Close</button>
+					<button class="btn btn-primary" type="button">Primary</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
 ```
 
 </article>

--- a/src/pages/docs/components/modals.md
+++ b/src/pages/docs/components/modals.md
@@ -54,6 +54,14 @@ weight: 100
 	{param title: 'Modal Title' /}
 {/call}
 ```
+```webcomponents
+<clay-modal
+	body="<h4>Modal Body</h4>"
+	footerButtons='[{"label": "Primary"},{"label": "Close", "type": "close"}]' size="sm"
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Modal Title">
+</clay-modal>
+```
 ```text/html
 <button class="btn btn-info" data-target="#claySmallModal" data-toggle="modal" type="button">Small Modal</button>
 <div aria-labelledby="claySmallModalLabel" class="fade modal" id="claySmallModal" role="dialog" tabindex="-1">
@@ -128,6 +136,13 @@ weight: 100
 	{param spritemap: '/vendor/lexicon/icons.svg' /}
 	{param title: 'Modal Title' /}
 {/call}
+```
+```webcomponents
+<clay-modal
+	body="<h4>Modal Body</h4>"
+	footerButtons='[{"label": "Primary"},{"label": "Close", "type": "close"}]' spritemap="/vendor/lexicon/icons.svg"
+	title="Modal Title">
+</clay-modal>
 ```
 ```text/html
 <button class="btn btn-info" data-target="#clayDefaultModal" data-toggle="modal" type="button">Default Modal</button>
@@ -206,6 +221,14 @@ weight: 100
 	{param spritemap: '/vendor/lexicon/icons.svg' /}
 	{param title: 'Modal Title' /}
 {/call}
+```
+```webcomponents
+<clay-modal
+	body="<h4>Modal Body</h4>"
+	footerButtons='[{"label": "Primary"},{"label": "Close", "type": "close"}]' size="lg"
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Modal Title">
+</clay-modal>
 ```
 ```text/html
 <button class="btn btn-info" data-target="#clayLargeModal" data-toggle="modal" type="button">Large Modal</button>
@@ -540,6 +563,14 @@ weight: 100
 	{param title: 'Add Picture to Documents and Media Library in Liferay Seven' /}
 {/call}
 ```
+```webcomponents
+<clay-modal
+	body="..."
+	footerButtons='[{"label": "Add"},{"label": "Close", "type": "close"}]' size="full-screen"
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Add Picture to Documents and Media Library in Liferay Seven">
+</clay-modal>
+```
 ```text/html
 <button class="btn btn-info" data-target="#clayFullScreenModal" data-toggle="modal" type="button">Full Screen Modal</button>
 <div aria-labelledby="clayLargeModalLabel" class="fade modal" id="clayFullScreenModal" role="dialog" tabindex="-1">
@@ -784,6 +815,13 @@ weight: 100
 	{param title: 'Add Picture to Documents and Media Library in Liferay Seven' /}
 	{param url: 'https://claycss.com' /}
 {/call}
+```
+```webcomponents
+<clay-modal
+	footerButtons='[{"label": "Add"},{"label": "Close", "type": "close"}]' size="full-screen"
+	spritemap="/vendor/lexicon/icons.svg"
+	title="Add Picture to Documents and Media Library in Liferay Seven" url="https://claycss.com">
+</clay-modal>
 ```
 ```text/html
 <button class="btn btn-info" data-target="#clayFullScreenModalIframe" data-toggle="modal" type="button">Full Screen Modal Iframe</button>
@@ -1042,6 +1080,35 @@ weight: 100
 	{param status: 'warning' /}
 	{param title: 'Modal Title' /}
 {/call}
+```
+```webcomponents
+<clay-modal
+	footerButtons='[{"label": "Add"},{"label": "Close", "type": "close"}]' size="full-screen"
+	spritemap="/vendor/lexicon/icons.svg"
+	status="danger"
+	title="Modal Title">
+</clay-modal>
+
+<clay-modal
+	footerButtons='[{"label": "Add"},{"label": "Close", "type": "close"}]' size="full-screen"
+	spritemap="/vendor/lexicon/icons.svg"
+	status="info"
+	title="Modal Title">
+</clay-modal>
+
+<clay-modal
+	footerButtons='[{"label": "Add"},{"label": "Close", "type": "close"}]' size="full-screen"
+	spritemap="/vendor/lexicon/icons.svg"
+	status="success"
+	title="Modal Title">
+</clay-modal>
+
+<clay-modal
+	footerButtons='[{"label": "Add"},{"label": "Close", "type": "close"}]' size="full-screen"
+	spritemap="/vendor/lexicon/icons.svg"
+	status="warning"
+	title="Modal Title">
+</clay-modal>
 ```
 ```text/html
 <button class="btn btn-danger" data-target="#clayModalDanger" data-toggle="modal" type="button">Modal Danger</button>

--- a/src/pages/docs/components/progress_bars.md
+++ b/src/pages/docs/components/progress_bars.md
@@ -42,6 +42,27 @@ weight: 100
 	</div>
 </div>
 
+```soy
+{call ClayProgressBar.render}
+	{param minValue: 0 /}
+	{param maxValue: 100 /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param value: 30 /}
+{/call}
+
+{call ClayProgressBar.render}
+	{param minValue: 0 /}
+	{param maxValue: 100 /}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param status: 'warning' /}
+	{param value: 70 /}
+{/call}
+
+{call ClayProgressBar.render}
+	{param spritemap: '/vendor/lexicon/icons.svg' /}
+	{param status: 'complete' /}
+{/call}
+```
 ```text/html
 <div class="progress-group">
 	<div class="progress">
@@ -69,27 +90,6 @@ weight: 100
 		</div>
 	</div>
 </div>
-```
-```soy
-{call ClayProgressBar.render}
-	{param minValue: 0 /}
-	{param maxValue: 100 /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param value: 30 /}
-{/call}
-
-{call ClayProgressBar.render}
-	{param minValue: 0 /}
-	{param maxValue: 100 /}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param status: 'warning' /}
-	{param value: 70 /}
-{/call}
-
-{call ClayProgressBar.render}
-	{param spritemap: '/vendor/lexicon/icons.svg' /}
-	{param status: 'complete' /}
-{/call}
 ```
 
 </article>

--- a/src/pages/docs/components/progress_bars.md
+++ b/src/pages/docs/components/progress_bars.md
@@ -63,6 +63,27 @@ weight: 100
 	{param status: 'complete' /}
 {/call}
 ```
+```webcomponents
+<clay-progress-bar
+	minValue="0"
+	maxValue="100"
+	spritemap="/vendor/lexicon/icons.svg"
+	value="30">
+</clay-progress-bar>
+
+<clay-progress-bar
+	minValue="0"
+	maxValue="100"
+	spritemap="/vendor/lexicon/icons.svg"
+	status="warning"
+	value="70">
+</clay-progress-bar>
+
+<clay-progress-bar
+	spritemap="/vendor/lexicon/icons.svg"
+	status="complete">
+</clay-progress-bar>
+```
 ```text/html
 <div class="progress-group">
 	<div class="progress">


### PR DESCRIPTION
Just adding examples of components with **WebComponents** and adding the soy examples first in the tabs.

The **highlights** not use with **WebComponents**, any suggestion?

* Alerts
* Badges
* Labels
* Stickers
* Buttons
* Checkbox
* Radio
* Icons
* Modals
* ProgressBar